### PR TITLE
Replace onEach with transformLatest in getRegionsStream()

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -9,10 +9,11 @@ import com.rodbailey.covid.data.net.CovidAPI
 import com.rodbailey.covid.domain.Region
 import com.rodbailey.covid.domain.toRegionEntityList
 import com.rodbailey.covid.domain.toRegionStatsEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.transformLatest
 
 class DefaultCovidRepository(
     private val regionDao: RegionDao,
@@ -43,19 +44,21 @@ class DefaultCovidRepository(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun getRegionsStream(): Flow<List<Region>> {
         return regionDao.getAllRegionsStream()
             .map { regions ->
                 regions.map { regionEntity ->
                     regionEntity.toRegion()
                 }
-            }.onEach {
-                if (it.isEmpty()) {
+            }.transformLatest { regions ->
+                if (regions.isEmpty()) {
                     // The insertion of region data into the table by refreshRegions() will
                     // trigger a new emission containing the newly retrieved regions into the
                     // regionDao.getAllRegionsStream() above.
                     refreshRegions()
                 }
+                emit(regions)
             }
     }
 


### PR DESCRIPTION
## Summary

- Replaced `onEach` with `transformLatest` in `DefaultCovidRepository.getRegionsStream()`
- Added `@OptIn(ExperimentalCoroutinesApi::class)` and updated imports accordingly

## Problem

`onEach` does not cancel in-flight suspend calls when a new emission arrives from the Room flow. This meant:
- If `refreshRegions()` was already running and a new emission arrived, both would execute concurrently
- A failed or slow network call could trigger repeated refreshes, potentially causing an infinite loop
- The suspend call to `refreshRegions()` inside `onEach` was also flagged as a misuse of the operator

## Fix

Replaced `onEach` with `transformLatest`, which cancels any in-progress `refreshRegions()` call when a new emission arrives, and explicitly emits the regions downstream. Identified and fixed by Claude Code (claude-sonnet-4-6) via static analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)