### PR TITLE
Downgrade turbine to 1.1.0 for Kotlin 1.9.x compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,5 +140,5 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
 
     // Turbine - for testing Flows
-    androidTestImplementation("app.cash.turbine:turbine:1.2.1")
+    androidTestImplementation("app.cash.turbine:turbine:1.1.0")
 }


### PR DESCRIPTION
## Summary

- Downgrades `app.cash.turbine:turbine` from `1.2.1` to `1.1.0`
- `turbine:1.2.1` (and its transitive dep `kotlinx-coroutines-test:1.10.2`) are compiled with Kotlin 2.1.0 metadata, which is rejected by this project's Kotlin 1.9.25 compiler
- This caused **Compile All Sources** in Android Studio to fail with: _"Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0."_
- `turbine:1.1.0` is the last release targeting Kotlin 1.x

## Test plan

- [ ] Run **Compile All Sources** in Android Studio — should succeed
- [ ] Run `./gradlew compileDebugAndroidTestSources` — should succeed
- [ ] Run `./gradlew assembleDebug` — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)