### PR TITLE
fix: remove suspend from getRegionStatsStream

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
@@ -30,7 +30,7 @@ class FakeCovidRepository() : CovidRepository {
             FakeRegions.REGIONS.keys.toList())
     }
 
-    override suspend fun getRegionStatsStream(iso3code: RegionCode): Flow<List<RegionStats>> {
+    override fun getRegionStatsStream(iso3code: RegionCode): Flow<List<RegionStats>> {
         if (allMethodsThrowException) {
             throw RuntimeException()
         }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
@@ -17,6 +17,6 @@ interface CovidRepository {
     /**
      * @return Cold flow of covid stats for the given region - completes after one emission
      */
-    suspend fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>>
+    fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>>
 
 }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -11,7 +11,7 @@ import com.rodbailey.covid.domain.toRegionEntityList
 import com.rodbailey.covid.domain.toRegionStatsEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
 
@@ -22,9 +22,9 @@ class DefaultCovidRepository(
 ) : CovidRepository {
 
 
-    override suspend fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>> {
+    override fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>> = flow {
         val dbStats = regionStatsDao.getRegionStats(code.chars)
-        return flowOf(
+        emit(
             if (dbStats.isEmpty()) {
                 val report = covidApi.getReport(codeToApiQueryParam(code))
                 val entity = report.data.toRegionStatsEntity(code.chars)


### PR DESCRIPTION
## Summary

- `getRegionStatsStream` was declared `suspend` in `CovidRepository` despite returning a `Flow` — an unusual contract where suspension happened before the flow was constructed rather than at collection time
- Replaced `flowOf(suspendingWork)` with `flow { emit(suspendingWork) }` in `DefaultCovidRepository` so suspension happens inside the flow builder, following the standard Kotlin Flow pattern
- Removed `suspend` modifier from the interface and `FakeCovidRepository` to match

## Test plan

- [ ] Existing instrumented tests pass: `./gradlew connectedAndroidTest`
- [ ] Verify region stats load correctly for both a specific region and global

🤖 Generated with [Claude Code](https://claude.com/claude-code)