### PR TITLE
fix: make injected repo private in MainViewModel

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    val repo: CovidRepository,
+    private val repo: CovidRepository,
 ) :
     ViewModel() {
 


### PR DESCRIPTION
## Summary

- `repo` was declared `val` (public) in the `MainViewModel` constructor, exposing the repository directly to external callers and allowing ViewModel logic to be bypassed
- Changed to `private val` — no external code references `viewModel.repo` directly, so this is a safe, non-breaking change

## Test plan

- [ ] `./gradlew connectedAndroidTest` — verify all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)