### PR TITLE
fix: remove ExpandDataPanel intent and expandDataPanel() method

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -66,7 +66,6 @@ class MainViewModel @Inject constructor(
      * How the view communicates intent/actions to this ViewModel.
      */
     sealed interface MainIntent {
-        data object ExpandDataPanel : MainIntent
         data object CollapseDataPanel : MainIntent
         data object LoadReportDataForGlobal : MainIntent
         data class LoadReportDataForRegion(
@@ -115,7 +114,6 @@ class MainViewModel @Inject constructor(
     fun processIntent(mainIntent: MainIntent) {
         when (mainIntent) {
             is CollapseDataPanel -> collapseDataPanel()
-            is MainIntent.ExpandDataPanel -> expandDataPanel()
             is LoadReportDataForGlobal -> loadReportDataForGlobal()
             is LoadReportDataForRegion -> loadReportDataForRegion(
                 mainIntent.regionName,
@@ -131,10 +129,6 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             errorChannel.send(message)
         }
-    }
-
-    private fun expandDataPanel() {
-        dataPanelUIState.value = DataPanelUIState.DataPanelOpenWithLoading
     }
 
     private fun collapseDataPanel() {


### PR DESCRIPTION
## Summary

- `ExpandDataPanel` set the panel to `DataPanelOpenWithLoading` but never triggered a data load, leaving the panel spinning indefinitely
- It was never referenced by the UI or any test — dead code
- The loading state is already set at the start of `loadReportDataForRegion()`, so the intent was fully redundant
- Removed: the `ExpandDataPanel` intent declaration, its `when` branch in `processIntent()`, and the `expandDataPanel()` method

## Test plan

- [ ] `./gradlew connectedAndroidTest` — verify data panel behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)