### PR TITLE
refactor: avoid redundant region filtering on data panel state changes

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -85,15 +85,19 @@ class MainViewModel @Inject constructor(
     private val searchText = MutableStateFlow("")
     private val dataPanelUIState = MutableStateFlow<DataPanelUIState>(DataPanelClosed)
 
+    // Filtered region list recomputed only when regions or search text change
+    private val filteredRegions = combine(regions, searchText) { aRegions, aSearchText ->
+        Pair(matchingRegionsResult(aRegions, aSearchText), aSearchText)
+    }
+
     // Communicates UI state changes to the view
     val uiState: StateFlow<UIState> = combine(
-        regions,
-        searchText,
+        filteredRegions,
         dataPanelUIState,
-    ) { aRegions, aSearchText, aDataPanelUIState ->
+    ) { (aMatchingRegions, aSearchText), aDataPanelUIState ->
         UIState(
             dataPanelUIState = aDataPanelUIState,
-            matchingRegions = matchingRegionsResult(aRegions, aSearchText),
+            matchingRegions = aMatchingRegions,
             searchText = aSearchText
         )
     }.stateIn(


### PR DESCRIPTION
## Summary

- The single `combine()` over `regions`, `searchText`, and `dataPanelUIState` caused `matchingRegionsResult()` to re-sort and re-filter the region list on every panel open/close, even when neither `regions` nor `searchText` had changed
- Split into two `combine()` calls:
  - `filteredRegions` — combines `regions` + `searchText`, recomputing the filtered list only when those two inputs change
  - `uiState` — combines `filteredRegions` + `dataPanelUIState`, so panel transitions no longer trigger unnecessary filtering work

## Test plan

- [ ] `./gradlew connectedAndroidTest` — verify search filtering and panel open/close behaviour are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)