### PR TITLE
Improve UIText semantics and composable-branch test coverage

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextComposableAsStringTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextComposableAsStringTest.kt
@@ -1,0 +1,59 @@
+package com.rodbailey.covid.presentation.core
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rodbailey.covid.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UITextComposableAsStringTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun asString_composable_dynamicString_branch() {
+        var actual = ""
+
+        composeRule.setContent {
+            actual = UIText.DynamicString("Bob").asString()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals("Bob", actual)
+        }
+    }
+
+    @Test
+    fun asString_composable_stringResource_branch() {
+        var actual = ""
+
+        composeRule.setContent {
+            actual = UIText.StringResource(R.string.region_global).asString()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals("Global", actual)
+        }
+    }
+
+    @Test
+    fun asString_composable_compoundStringResource_branch() {
+        var actual = ""
+
+        composeRule.setContent {
+            actual = UIText.CompoundStringResource(
+                R.string.failed_to_load_data_for,
+                UIText.StringResource(R.string.region_global)
+            ).asString()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals("Failed to load data for \"Global\".", actual)
+        }
+    }
+}
+

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextTest.kt
@@ -1,7 +1,8 @@
 package com.rodbailey.covid.presentation.core
 
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import com.rodbailey.covid.R
 
@@ -13,14 +14,39 @@ class UITextTest {
     fun dynamic_string_as_string() {
         val dynamicString = UIText.DynamicString("Bob")
         val result = dynamicString.asString(context)
-        Assert.assertEquals("Bob", result)
+        assertEquals("Bob", result)
+    }
+
+    @Test
+    fun dynamic_string_as_string_preserves_empty_and_whitespace() {
+        assertEquals("", UIText.DynamicString("").asString(context))
+        assertEquals("  Bob  ", UIText.DynamicString("  Bob  ").asString(context))
     }
 
     @Test
     fun string_resource_as_string() {
         val stringResource = UIText.StringResource(R.string.region_global)
         val result = stringResource.asString(context)
-        Assert.assertEquals("Global", result)
+        assertEquals("Global", result)
+    }
+
+    @Test
+    fun string_resource_as_string_with_vararg_format_arg() {
+        val stringResource = UIText.StringResource(R.string.failed_to_load_data_for, "France")
+        val result = stringResource.asString(context)
+        val expected = context.getString(R.string.failed_to_load_data_for, "France")
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun string_resource_as_string_with_list_args_format_arg() {
+        val stringResource = UIText.StringResource(
+            resId = R.string.failed_to_load_data_for,
+            args = listOf("Brazil")
+        )
+        val result = stringResource.asString(context)
+        val expected = context.getString(R.string.failed_to_load_data_for, "Brazil")
+        assertEquals(expected, result)
     }
 
     @Test
@@ -29,6 +55,80 @@ class UITextTest {
         val compoundStringResource = UIText.CompoundStringResource(
             R.string.failed_to_load_data_for, stringResource)
         val result = compoundStringResource.asString(context)
-        Assert.assertEquals("Failed to load data for \"Global\".", result)
+        assertEquals("Failed to load data for \"Global\".", result)
+    }
+
+    @Test
+    fun compound_string_resource_with_dynamic_inner_text() {
+        val inner = UIText.DynamicString("Japan")
+        val compound = UIText.CompoundStringResource(R.string.failed_to_load_data_for, inner)
+        val expected = context.getString(R.string.failed_to_load_data_for, "Japan")
+        assertEquals(expected, compound.asString(context))
+    }
+
+    @Test
+    fun compound_string_resource_nested_compound_is_resolved_recursively() {
+        val inner = UIText.CompoundStringResource(
+            R.string.failed_to_load_data_for,
+            UIText.StringResource(R.string.region_global)
+        )
+        val outer = UIText.CompoundStringResource(R.string.failed_to_load_data_for, inner)
+
+        val innerExpected = context.getString(
+            R.string.failed_to_load_data_for,
+            context.getString(R.string.region_global)
+        )
+        val expected = context.getString(R.string.failed_to_load_data_for, innerExpected)
+
+        assertEquals(expected, outer.asString(context))
+    }
+
+    @Test
+    fun data_class_value_semantics_dynamic_string() {
+        val a = UIText.DynamicString("Global")
+        val b = UIText.DynamicString("Global")
+        val c = a.copy(value = "Brazil")
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun data_class_value_semantics_string_resource() {
+        val a = UIText.StringResource(R.string.failed_to_load_data_for, "Global")
+        val b = UIText.StringResource(
+            resId = R.string.failed_to_load_data_for,
+            args = listOf("Global")
+        )
+        val c = a.copy(args = listOf("Brazil"))
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun data_class_value_semantics_compound_resource() {
+        val a = UIText.CompoundStringResource(
+            R.string.failed_to_load_data_for,
+            UIText.StringResource(R.string.region_global)
+        )
+        val b = UIText.CompoundStringResource(
+            R.string.failed_to_load_data_for,
+            UIText.StringResource(R.string.region_global)
+        )
+        val c = a.copy(uiText = UIText.DynamicString("Canada"))
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun different_ui_text_types_with_similar_content_are_not_equal() {
+        val dynamic = UIText.DynamicString("Global")
+        val resource = UIText.StringResource(R.string.region_global)
+        assertNotEquals(dynamic, resource)
     }
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
@@ -19,15 +19,17 @@ sealed class UIText {
     /**
      * String from XML resource
      */
-    class StringResource(
+    data class StringResource(
         @StringRes val resId: Int,
-        vararg val args: Any
-    ) : UIText()
+        val args: List<Any> = emptyList()
+    ) : UIText() {
+        constructor(@StringRes resId: Int, vararg args: Any) : this(resId, args.toList())
+    }
 
     /**
      * String from XML resource and another [UIText]
      */
-    class CompoundStringResource(
+    data class CompoundStringResource(
         @StringRes val resId: Int,
         val uiText: UIText
     ) : UIText()
@@ -36,7 +38,7 @@ sealed class UIText {
     fun asString(): String {
         return when (this) {
             is DynamicString -> value
-            is StringResource -> stringResource(resId, args)
+            is StringResource -> stringResource(resId, *args.toTypedArray())
             is CompoundStringResource -> stringResource(resId, uiText.asString())
         }
     }
@@ -44,7 +46,7 @@ sealed class UIText {
     fun asString(ctx: Context): String {
         return when (this) {
             is DynamicString -> value
-            is StringResource -> ctx.getString(resId, *args)
+            is StringResource -> ctx.getString(resId, *args.toTypedArray())
             is CompoundStringResource -> ctx.getString(resId, uiText.asString(ctx))
         }
     }


### PR DESCRIPTION
This PR improves UIText correctness and expands coverage for both context-based and composable string rendering.
Changes include:
- Convert UIText resource wrappers to data classes for value semantics
- Fix Compose formatting path to pass varargs correctly
- Expand UIText instrumented tests for formatting, nesting, and value semantics
- Add UITextComposableAsStringTest to exercise all composable asString() when branches