### PR TITLE
fix: gate HTTP logging interceptor on BuildConfig.DEBUG

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/data/net/CovidAPIClient.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/net/CovidAPIClient.kt
@@ -1,5 +1,6 @@
 package com.rodbailey.covid.data.net
 
+import com.rodbailey.covid.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -9,7 +10,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 class CovidAPIClient {
     fun getAPIClient(): CovidAPI {
         val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
+            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                    else HttpLoggingInterceptor.Level.NONE
         }
 
         val client = OkHttpClient.Builder().addInterceptor(loggingInterceptor).build()

--- a/app/src/main/java/com/rodbailey/covid/data/net/CovidAPIClient.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/net/CovidAPIClient.kt
@@ -9,17 +9,18 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class CovidAPIClient {
     fun getAPIClient(): CovidAPI {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-                    else HttpLoggingInterceptor.Level.NONE
-        }
+        val builder = OkHttpClient.Builder()
 
-        val client = OkHttpClient.Builder().addInterceptor(loggingInterceptor).build()
+        if (BuildConfig.DEBUG) {
+            val loggingInterceptor = HttpLoggingInterceptor()
+            loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+            builder.addInterceptor(loggingInterceptor)
+        }
 
         return Retrofit.Builder()
             .baseUrl("https://covid-api.com/")
             .addConverterFactory(GsonConverterFactory.create())
-            .client(client)
+            .client(builder.build())
             .build()
             .create(CovidAPI::class.java)
     }

--- a/bug_report.txt
+++ b/bug_report.txt
@@ -35,7 +35,7 @@ CRITICAL BUGS
 HIGH PRIORITY BUGS
 ==================
 
-4. HTTP logging interceptor always set to BODY level in production
+4. [FIXED - PR #27] HTTP logging interceptor always set to BODY level in production
    File: app/src/main/java/com/rodbailey/covid/data/net/CovidAPIClient.kt
    Lines: 11-13
    Detail: HttpLoggingInterceptor.Level.BODY is set unconditionally, logging full
@@ -85,6 +85,6 @@ MEDIUM PRIORITY BUGS
 SUMMARY
 =======
 Critical:  3 (3 fixed, 0 open)
-High:      2 (0 fixed, 2 open)
+High:      2 (1 fixed, 1 open)
 Medium:    3 (0 fixed, 3 open)
-Total:     8 (3 fixed, 5 open)
+Total:     8 (4 fixed, 4 open)


### PR DESCRIPTION
## Summary
- `HttpLoggingInterceptor` was unconditionally set to `BODY` level in `CovidAPIClient`, logging full request/response bodies in production builds
- Now logs at `BODY` in debug builds and `NONE` in release builds, eliminating the performance overhead and data exposure risk in production
- Fixes bug #4 from `bug_report.txt`

## Test plan
- [ ] All 42 instrumented tests pass
- [ ] All JVM unit tests pass
- [ ] Verify no HTTP logging appears in a release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)