### PR TITLE
refactor: rename regionStats to regionStatsList in MainViewModel

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -152,9 +152,9 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 dataPanelUIState.value = DataPanelUIState.DataPanelOpenWithLoading
-                val regionStats = repo.getRegionStatsStream(regionIso3Code).first()
+                val regionStatsList = repo.getRegionStatsStream(regionIso3Code).first()
                 dataPanelUIState.value =
-                    DataPanelOpenWithData(regionName, regionStats.first().toReportData())
+                    DataPanelOpenWithData(regionName, regionStatsList.first().toReportData())
             } catch (th: Throwable) {
                 Timber.e(th, "Exception while getting report data for region \"$regionName\"")
                 showErrorMessage(


### PR DESCRIPTION
## Summary
- Renames the local variable `regionStats` to `regionStatsList` in `loadReportDataForRegion()`
- `getRegionStatsStream()` returns `Flow<List<RegionStats>>`, so the result of `.first()` is a `List<RegionStats>`, not a single `RegionStats` — the old name was misleading and obscured why `.first()` was called again on the next line

## Test plan
- [ ] All 42 instrumented tests pass
- [ ] All JVM unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)