### PR TITLE
fix: cancel in-flight loadReportDataForRegion job on new request

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -148,8 +149,11 @@ class MainViewModel @Inject constructor(
         loadReportDataForRegion(UIText.StringResource(R.string.region_global), GlobalCode())
     }
 
+    private var loadReportJob: Job? = null
+
     private fun loadReportDataForRegion(regionName: UIText, regionIso3Code: RegionCode) {
-        viewModelScope.launch {
+        loadReportJob?.cancel()
+        loadReportJob = viewModelScope.launch {
             try {
                 dataPanelUIState.value = DataPanelUIState.DataPanelOpenWithLoading
                 val regionStatsList = repo.getRegionStatsStream(regionIso3Code).first()

--- a/bug_report.txt
+++ b/bug_report.txt
@@ -43,7 +43,7 @@ HIGH PRIORITY BUGS
    exposure risk.
    Fix: Gate on BuildConfig.DEBUG:
        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-               else HttpLoggi bugngInterceptor.Level.NONE
+               else HttpLoggingInterceptor.Level.NONE
 
 5. [FIXED] collectLatest on a cold flow triggers multiple concurrent network requests
    File: app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt

--- a/bug_report.txt
+++ b/bug_report.txt
@@ -43,9 +43,9 @@ HIGH PRIORITY BUGS
    exposure risk.
    Fix: Gate on BuildConfig.DEBUG:
        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-               else HttpLoggingInterceptor.Level.NONE
+               else HttpLoggi bugngInterceptor.Level.NONE
 
-5. collectLatest on a cold flow triggers multiple concurrent network requests
+5. [FIXED] collectLatest on a cold flow triggers multiple concurrent network requests
    File: app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
    Lines: ~150-172
    Detail: loadReportDataForRegion() uses collectLatest on a cold flow returned by
@@ -85,6 +85,6 @@ MEDIUM PRIORITY BUGS
 SUMMARY
 =======
 Critical:  3 (3 fixed, 0 open)
-High:      2 (1 fixed, 1 open)
+High:      2 (2 fixed, 0 open)
 Medium:    3 (0 fixed, 3 open)
-Total:     8 (4 fixed, 4 open)
+Total:     8 (5 fixed, 3 open)


### PR DESCRIPTION
## Summary
- Adds a `loadReportJob: Job?` field to `MainViewModel` to track the active region stats request
- Cancels the previous job before launching a new one in `loadReportDataForRegion()`, ensuring only one network request is in flight at a time
- Updates `bug_report.txt` to mark bug #5 as fixed
- Fixes bug #5 from `bug_report.txt`

## Test plan
- [ ] All 42 instrumented tests pass
- [ ] All JVM unit tests pass
- [ ] Manually verify that rapidly tapping different regions does not result in multiple overlapping network requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)