### PR TITLE
fix: prevent dropped errors (bug #8) and duplicate region inserts

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/rodbailey/covid/core/di/RepositoryModule.kt
@@ -9,12 +9,14 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 object RepositoryModule {
 
     @Provides
+    @Singleton
     fun provideCovidRepository(
         regionDao: RegionDao,
         regionStatsDao: RegionStatsDao,

--- a/app/src/main/java/com/rodbailey/covid/data/db/RegionDao.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/RegionDao.kt
@@ -12,4 +12,7 @@ interface RegionDao {
 
     @Query("select * from regions")
     fun getAllRegionsStream(): Flow<List<RegionEntity>>
+
+    @Query("select count(*) from regions")
+    suspend fun getRegionCount(): Int
 }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -69,7 +69,7 @@ class DefaultCovidRepository(
 
     private suspend fun refreshRegions() {
         // Mutex serialises concurrent callers (e.g. two collectors of the cold regions flow).
-        // "withLock" waits for the lock rather than skipping.ii
+        // "withLock" waits for the lock rather than skipping it.
         // Inside the lock we re-check the DB so the second caller skips the network request
         // if the first one already populated the table. ie. the second concurrent caller waits
         // for the first to finish, then finds the DB already populated and skips the

--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -14,12 +14,17 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
 
 class DefaultCovidRepository(
     private val regionDao: RegionDao,
     private val regionStatsDao: RegionStatsDao,
     private val covidApi: CovidAPI
 ) : CovidRepository {
+
+    private val refreshMutex = Mutex()
 
 
     override fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>> = flow {
@@ -63,11 +68,17 @@ class DefaultCovidRepository(
     }
 
     private suspend fun refreshRegions() {
-        covidApi.getRegions()
-            .also {
-                regionDao.insert(
-                    it.regions.toRegionEntityList()
-                )
+        // Mutex serialises concurrent callers (e.g. two collectors of the cold regions flow).
+        // "withLock" waits for the lock rather than skipping.ii
+        // Inside the lock we re-check the DB so the second caller skips the network request
+        // if the first one already populated the table. ie. the second concurrent caller waits
+        // for the first to finish, then finds the DB already populated and skips the
+        // network call covidApi.getRegions()
+        refreshMutex.withLock {
+            if (regionDao.getRegionCount() > 0) return@withLock
+            covidApi.getRegions().also {
+                regionDao.insert(it.regions.toRegionEntityList())
             }
+        }
     }
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -79,8 +79,10 @@ class MainViewModel @Inject constructor(
     }
 
     // Error text from network failures etc. Use a Channel to prevent event duplication on
-    // configuration change.
-    private val errorChannel = Channel<UIText>()
+    // configuration change. BUFFERED capacity avoids a race where an error is emitted before
+    // the UI has subscribed to errorFlow — with the default RENDEZVOUS (capacity=0) the send
+    // would suspend indefinitely and the error would be silently lost.
+    private val errorChannel = Channel<UIText>(Channel.BUFFERED)
     val errorFlow = errorChannel.receiveAsFlow()
 
     private val regions: Flow<Result<List<Region>>> = repo.getRegionsStream().asResult()

--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -80,8 +80,9 @@ class MainViewModel @Inject constructor(
 
     // Error text from network failures etc. Use a Channel to prevent event duplication on
     // configuration change. BUFFERED capacity avoids a race where an error is emitted before
-    // the UI has subscribed to errorFlow — with the default RENDEZVOUS (capacity=0) the send
-    // would suspend indefinitely and the error would be silently lost.
+    // the UI has subscribed to errorFlow — with the default RENDEZVOUS (capacity = 0) the send
+    // would suspend until there is a receiver, and the message could be lost if the sending
+    // coroutine is cancelled before a collector starts.
     private val errorChannel = Channel<UIText>(Channel.BUFFERED)
     val errorFlow = errorChannel.receiveAsFlow()
 

--- a/bug_report.txt
+++ b/bug_report.txt
@@ -76,7 +76,7 @@ MEDIUM PRIORITY BUGS
    is Error, nothing is displayed and the failure is silently swallowed.
    Fix: Add an else/is Error branch to show an error message to the user.
 
-8. Channel with default RENDEZVOUS capacity may drop errors
+8. [FIXED] Channel with default RENDEZVOUS capacity may drop errors
    File: app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
    Lines: 83-84
    Detail: errorChannel is created with default capacity (RENDEZVOUS = 0). If an error
@@ -89,5 +89,5 @@ SUMMARY
 =======
 Critical:  3 (3 fixed, 0 open)
 High:      2 (2 fixed, 0 open)
-Medium:    3 (2 fixed, 1 open)
-Total:     8 (7 fixed, 1 open)
+Medium:    3 (3 fixed, 0 open)
+Total:     8 (8 fixed, 0 open)

--- a/bug_report.txt
+++ b/bug_report.txt
@@ -1,6 +1,6 @@
 YStatic Analysis Bug Report — Covid Android App
 Generated: 2026-03-17
-Last updated: 2026-03-17
+Last updated: 2026-04-01
 ============================================================
 
 CRITICAL BUGS


### PR DESCRIPTION
- [x] Fix dropped errors (Bug #8) - `Channel.BUFFERED`
- [x] Fix duplicate region inserts - `Mutex` in `refreshRegions()`
- [x] Add `RegionDao.getRegionCount()`
- [x] Scope `CovidRepository` as `@Singleton` in `RepositoryModule`
- [x] Update `bug_report.txt` last-updated date