### PR TITLE
test: add TransformUtils edge case tests for blank name and unusual ISO3 codes

### DIFF
--- a/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
+++ b/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
@@ -99,6 +99,14 @@ class TransformUtilsTest {
     }
 
     @Test
+    fun regionEntityToRegion_preservesBlankName() {
+        assertEquals(
+            Region(iso3Code = "AUS", name = ""),
+            RegionEntity(iso3code = "AUS", name = "").toRegion()
+        )
+    }
+
+    @Test
     fun regionToRegionCode_preservesUnusualCharacters() {
         assertEquals(
             "A-1",

--- a/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
+++ b/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
@@ -99,7 +99,7 @@ class TransformUtilsTest {
     }
 
     @Test
-    fun regionEntityToRegion_preservesBlankName() {
+    fun regionEntityToRegionPreservesBlankName() {
         assertEquals(
             Region(iso3Code = "AUS", name = ""),
             RegionEntity(iso3code = "AUS", name = "").toRegion()
@@ -107,7 +107,7 @@ class TransformUtilsTest {
     }
 
     @Test
-    fun regionToRegionCode_preservesUnusualCharacters() {
+    fun regionToRegionCodePreservesUnusualCharacters() {
         assertEquals(
             "A-1",
             Region(iso3Code = "A-1", name = "Unusual").toRegionCode().chars
@@ -115,7 +115,7 @@ class TransformUtilsTest {
     }
 
     @Test
-    fun regionToRegionCode_preservesEmptyString() {
+    fun regionToRegionCodePreservesEmptyString() {
         assertEquals(
             "",
             Region(iso3Code = "", name = "Empty").toRegionCode().chars

--- a/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
+++ b/app/src/test/java/com/rodbailey/covid/domain/TransformUtilsTest.kt
@@ -97,4 +97,20 @@ class TransformUtilsTest {
             regionAus.toRegionCode().chars
         )
     }
+
+    @Test
+    fun regionToRegionCode_preservesUnusualCharacters() {
+        assertEquals(
+            "A-1",
+            Region(iso3Code = "A-1", name = "Unusual").toRegionCode().chars
+        )
+    }
+
+    @Test
+    fun regionToRegionCode_preservesEmptyString() {
+        assertEquals(
+            "",
+            Region(iso3Code = "", name = "Empty").toRegionCode().chars
+        )
+    }
 }

--- a/test_gaps.txt
+++ b/test_gaps.txt
@@ -26,7 +26,7 @@ Here's a summary of the most meaningful gaps, roughly in priority order:
 
 ### TransformUtilsTest.kt — Minor gaps
 - ~~No test for `regionToRegionCode` when the ISO3 code contains unusual characters or is an empty string~~ DONE: `regionToRegionCode_preservesUnusualCharacters`, `regionToRegionCode_preservesEmptyString`
-- No test for the reverse path: `RegionEntity → Region` when the name field is blank
+- ~~No test for the reverse path: `RegionEntity → Region` when the name field is blank~~ DONE: `regionEntityToRegion_preservesBlankName`
 
 The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mutex test, **(2)** the cache-hit path for regions~~, **(3)** job cancellation in `MainViewModel`, and **(4)** a `CollapseDataPanel` ViewModel test.
 
@@ -54,7 +54,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 
 ### Detailed Test Coverage by File
 
-#### **1. TransformUtilsTest.kt** (9 test scenarios)
+#### **1. TransformUtilsTest.kt** (10 test scenarios)
 
 **Tests:**
 - RegionStatsEntity → ReportData transformation
@@ -66,6 +66,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 - Region → RegionCode transformation
 - Region → RegionCode preserves unusual characters
 - Region → RegionCode preserves empty string
+- RegionEntity → Region preserves blank name
 
 **Coverage:** Tests all extension functions in domain layer for entity/domain object conversions.
 

--- a/test_gaps.txt
+++ b/test_gaps.txt
@@ -25,7 +25,7 @@ Here's a summary of the most meaningful gaps, roughly in priority order:
 - `ReportData` JSON mapping (`fatality_rate` → `fatalityRate`, etc.) is never tested; a wrong `@SerializedName` annotation would go undetected until a UI test fails
 
 ### TransformUtilsTest.kt — Minor gaps
-- No test for `regionToRegionCode` when the ISO3 code contains unusual characters or is an empty string
+- ~~No test for `regionToRegionCode` when the ISO3 code contains unusual characters or is an empty string~~ DONE: `regionToRegionCode_preservesUnusualCharacters`, `regionToRegionCode_preservesEmptyString`
 - No test for the reverse path: `RegionEntity → Region` when the name field is blank
 
 The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mutex test, **(2)** the cache-hit path for regions~~, **(3)** job cancellation in `MainViewModel`, and **(4)** a `CollapseDataPanel` ViewModel test.
@@ -54,7 +54,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 
 ### Detailed Test Coverage by File
 
-#### **1. TransformUtilsTest.kt** (7 test scenarios)
+#### **1. TransformUtilsTest.kt** (9 test scenarios)
 
 **Tests:**
 - RegionStatsEntity → ReportData transformation
@@ -64,6 +64,8 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 - List<Region> → List<RegionEntity> transformation
 - List<RegionEntity> → List<Region> transformation
 - Region → RegionCode transformation
+- Region → RegionCode preserves unusual characters
+- Region → RegionCode preserves empty string
 
 **Coverage:** Tests all extension functions in domain layer for entity/domain object conversions.
 


### PR DESCRIPTION
- [x] Add `regionToRegionCodePreservesUnusualCharacters` — verifies non-alpha characters in ISO3 code pass through unchanged
- [x] Add `regionToRegionCodePreservesEmptyString` — verifies empty ISO3 code passes through unchanged
- [x] Add `regionEntityToRegionPreservesBlankName` — verifies blank name passes through unchanged
- [x] Rename all three new test methods from snake_case to camelCase to match existing naming convention
- [x] Update `test_gaps.txt` to mark all three gaps as resolved