### PR TITLE
test: add CollapseDataPanel intent test to MainViewModelTest

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -194,13 +194,13 @@ class MainViewModelTest {
     @Test
     fun collapse_data_panel_intent_closes_open_data_panel() = runTest {
         viewModel.uiState.test {
-            awaitItem() // Result.Loading
-            awaitItem() // Result.Success (empty regions)
-            awaitItem() // Result.Success (regions loaded)
+            // Skip initial emissions: loading, empty regions, and regions loaded
+            skipItems(3)
 
             // Open the data panel first
             viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
-            awaitItem() // DataPanelOpenWithLoading
+            val loadingPanelState = awaitItem()
+            Assert.assertTrue(loadingPanelState.dataPanelUIState is DataPanelOpenWithLoading)
             val openState = awaitItem()
             Assert.assertTrue(openState.dataPanelUIState is MainViewModel.DataPanelUIState.DataPanelOpenWithData)
 

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -192,6 +192,26 @@ class MainViewModelTest {
     }
 
     @Test
+    fun collapse_data_panel_intent_closes_open_data_panel() = runTest {
+        viewModel.uiState.test {
+            awaitItem() // Result.Loading
+            awaitItem() // Result.Success (empty regions)
+            awaitItem() // Result.Success (regions loaded)
+
+            // Open the data panel first
+            viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
+            awaitItem() // DataPanelOpenWithLoading
+            val openState = awaitItem()
+            Assert.assertTrue(openState.dataPanelUIState is MainViewModel.DataPanelUIState.DataPanelOpenWithData)
+
+            // Now collapse it
+            viewModel.processIntent(MainViewModel.MainIntent.CollapseDataPanel)
+            val closedState = awaitItem()
+            Assert.assertTrue(closedState.dataPanelUIState is DataPanelClosed)
+        }
+    }
+
+    @Test
     fun empty_country_stats_closes_data_panel_and_shows_error() = runTest {
         (fakeCovidRepository as FakeCovidRepository).setRegionStatsEmpty(true)
         viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)

--- a/test_gaps.txt
+++ b/test_gaps.txt
@@ -8,7 +8,7 @@ Here's a summary of the most meaningful gaps, roughly in priority order:
 - ~~**`codeToApiQueryParam()`** — no test that `GlobalCode` maps to `null` and a `RegionCode` maps to its ISO3 string~~ DONE: `global_code_passes_null_to_api`, `region_code_passes_iso3_string_to_api`
 
 ### MainViewModelTest.kt — State transitions
-- **`CollapseDataPanel` intent** — closing the data panel is never directly tested; only tested implicitly via UI test
+- ~~**`CollapseDataPanel` intent** — closing the data panel is never directly tested; only tested implicitly via UI test~~ DONE: `collapse_data_panel_intent_closes_open_data_panel`
 - **Successful region stats load (non-global)** — there's no test verifying `DataPanelUIState.OpenWithData` for a regular country (only global is tested)
 - **Job cancellation** — if a second `LoadReportDataForRegion` arrives while the first is still in flight, the first job should be cancelled; this is untested
 - **Data panel state on error** — `DataPanelUIState` transitions to `Closed` when a stats-load error occurs, but no ViewModel test covers this (only the error channel message is tested)


### PR DESCRIPTION
## Summary
- Adds `collapse_data_panel_intent_closes_open_data_panel` to `MainViewModelTest` — opens the data panel via `LoadReportDataForGlobal`, asserts it reaches `DataPanelOpenWithData`, then sends `CollapseDataPanel` and asserts the transition to `DataPanelClosed`
- Updates `test_gaps.txt` to mark this gap as resolved

## Test plan
- [ ] All 50 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] All unit tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)