### PR TITLE
test: add MainViewModelTest case for data panel closing on stats load error

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -229,13 +229,17 @@ class MainViewModelTest {
             skipItems(3) // Result.Loading, Result.Success (empty), Result.Success (loaded)
 
             (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
-            viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
+            try {
+                viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
 
-            val loadingState = awaitItem()
-            Assert.assertTrue(loadingState.dataPanelUIState is DataPanelOpenWithLoading)
+                val loadingState = awaitItem()
+                Assert.assertTrue(loadingState.dataPanelUIState is DataPanelOpenWithLoading)
 
-            val errorState = awaitItem()
-            Assert.assertTrue(errorState.dataPanelUIState is DataPanelClosed)
+                val errorState = awaitItem()
+                Assert.assertTrue(errorState.dataPanelUIState is DataPanelClosed)
+            } finally {
+                (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(false)
+            }
         }
     }
 

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -224,6 +224,22 @@ class MainViewModelTest {
     }
 
     @Test
+    fun stats_load_exception_closes_data_panel() = runTest {
+        viewModel.uiState.test {
+            skipItems(3) // Result.Loading, Result.Success (empty), Result.Success (loaded)
+
+            (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
+            viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
+
+            val loadingState = awaitItem()
+            Assert.assertTrue(loadingState.dataPanelUIState is DataPanelOpenWithLoading)
+
+            val errorState = awaitItem()
+            Assert.assertTrue(errorState.dataPanelUIState is DataPanelClosed)
+        }
+    }
+
+    @Test
     fun exception_from_api_when_loading_country_list_results_in_error_message() = runTest {
         // Flag must be set before ViewModel construction so the regions flow throws on collection
         (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(true)

--- a/test_gaps.txt
+++ b/test_gaps.txt
@@ -11,7 +11,7 @@ Here's a summary of the most meaningful gaps, roughly in priority order:
 - ~~**`CollapseDataPanel` intent** — closing the data panel is never directly tested; only tested implicitly via UI test~~ DONE: `collapse_data_panel_intent_closes_open_data_panel`
 - **Successful region stats load (non-global)** — there's no test verifying `DataPanelUIState.OpenWithData` for a regular country (only global is tested)
 - **Job cancellation** — if a second `LoadReportDataForRegion` arrives while the first is still in flight, the first job should be cancelled; this is untested
-- **Data panel state on error** — `DataPanelUIState` transitions to `Closed` when a stats-load error occurs, but no ViewModel test covers this (only the error channel message is tested)
+- ~~**Data panel state on error** — `DataPanelUIState` transitions to `Closed` when a stats-load error occurs, but no ViewModel test covers this (only the error channel message is tested)~~ DONE: `stats_load_exception_closes_data_panel`
 
 ### RegionDbTest.kt / RegionStatsDbTest.kt — DB edge cases
 - **Flow emits on update** — `getAllRegionsStream()` is a `Flow`; no test verifies it emits a second time when the table is modified after initial subscription
@@ -110,7 +110,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 
 ---
 
-#### **5. MainViewModelTest.kt** (11 test scenarios)
+#### **5. MainViewModelTest.kt** (12 test scenarios)
 
 **Tests:**
 - Sorted region list loads at startup
@@ -124,6 +124,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 - Exception from API when loading country list results in error message
 - Exception from API when loading country stats results in error message
 - (Implicit: OnSearchTextChanged intent processing)
+- Stats load exception transitions data panel to closed
 
 **Coverage:** Tests MainViewModel state management, search filtering, data panel loading, and error handling with FakeCovidRepository.
 


### PR DESCRIPTION
## Summary
- Adds `stats_load_exception_closes_data_panel` to `MainViewModelTest` — triggers a stats load, observes `DataPanelOpenWithLoading`, then asserts the panel transitions to `DataPanelClosed` when the repository throws an exception
- Updates `test_gaps.txt` to mark this gap as resolved

## Test plan
- [ ] All 51 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] All unit tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)