### PR TITLE
test: add ReportData JSON deserialization tests

### DIFF
--- a/app/src/test/java/com/rodbailey/covid/domain/ReportDataDeserializationTest.kt
+++ b/app/src/test/java/com/rodbailey/covid/domain/ReportDataDeserializationTest.kt
@@ -1,0 +1,58 @@
+package com.rodbailey.covid.domain
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReportDataDeserializationTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun all_fields_deserialize_correctly_from_json() {
+        val json = """
+            {
+              "confirmed": 1000,
+              "deaths": 200,
+              "recovered": 700,
+              "active": 100,
+              "fatality_rate": 0.25
+            }
+        """.trimIndent()
+
+        val result = gson.fromJson(json, ReportData::class.java)
+
+        assertEquals(1000L, result.confirmed)
+        assertEquals(200L, result.deaths)
+        assertEquals(700L, result.recovered)
+        assertEquals(100L, result.active)
+        assertEquals(0.25F, result.fatalityRate, 0.001F)
+    }
+
+    @Test
+    fun fatality_rate_snake_case_key_maps_to_fatalityRate_property() {
+        // A wrong @SerializedName would silently leave fatalityRate at its default of -1F
+        val json = """{"fatality_rate": 3.14}"""
+        val result = gson.fromJson(json, ReportData::class.java)
+        assertEquals(3.14F, result.fatalityRate, 0.001F)
+    }
+
+    @Test
+    fun missing_fields_produce_default_values() {
+        val result = gson.fromJson("{}", ReportData::class.java)
+        assertEquals(-1L, result.confirmed)
+        assertEquals(-1L, result.deaths)
+        assertEquals(-1L, result.recovered)
+        assertEquals(-1L, result.active)
+        assertEquals(-1F, result.fatalityRate, 0.001F)
+    }
+
+    @Test
+    fun report_data_field_unwraps_correctly_from_report_json() {
+        // Verifies the Report wrapper's @SerializedName("data") mapping
+        val json = """{"data": {"confirmed": 42, "fatality_rate": 1.5}}"""
+        val report = gson.fromJson(json, Report::class.java)
+        assertEquals(42L, report.data.confirmed)
+        assertEquals(1.5F, report.data.fatalityRate, 0.001F)
+    }
+}

--- a/test_gaps.md
+++ b/test_gaps.md
@@ -21,8 +21,8 @@ Here's a summary of the most meaningful gaps, roughly in priority order:
 - **Network exception during `getRegions()`** — exception should propagate to callers; never tested at the repository level
 - **Network exception during `getRegionStats()`** — same gap
 
-### Deserialization (no tests exist)
-- `ReportData` JSON mapping (`fatality_rate` → `fatalityRate`, etc.) is never tested; a wrong `@SerializedName` annotation would go undetected until a UI test fails
+### Deserialization
+- ~~`ReportData` JSON mapping (`fatality_rate` → `fatalityRate`, etc.) is never tested; a wrong `@SerializedName` annotation would go undetected until a UI test fails~~ DONE: `all_fields_deserialize_correctly_from_json`, `fatality_rate_snake_case_key_maps_to_fatalityRate_property`, `missing_fields_produce_default_values`, `report_data_field_unwraps_correctly_from_report_json`
 
 ### TransformUtilsTest.kt — Minor gaps
 - ~~No test for `regionToRegionCode` when the ISO3 code contains unusual characters or is an empty string~~ DONE: `regionToRegionCode_preservesUnusualCharacters`, `regionToRegionCode_preservesEmptyString`


### PR DESCRIPTION
## Summary
- Adds a new unit test class `ReportDataDeserializationTest` with 4 tests:
  - `all_fields_deserialize_correctly_from_json` — verifies all five fields map correctly from JSON
  - `fatality_rate_snake_case_key_maps_to_fatalityRate_property` — isolates the `@SerializedName("fatality_rate")` mapping; a typo would silently produce `-1F`
  - `missing_fields_produce_default_values` — verifies absent JSON fields fall back to `-1` defaults
  - `report_data_field_unwraps_correctly_from_report_json` — verifies the `Report` wrapper's `@SerializedName("data")` mapping
- Uses `Gson` directly (already on the classpath via Retrofit) — runs as a JVM unit test with no device required
- Updates `test_gaps.md` to mark this gap as resolved

## Test plan
- [ ] All unit tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)