### PR TITLE
test: add MainUITest case for failed stats load leaving data panel closed

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -203,13 +203,14 @@ class MainUITest {
     @Test
     fun failed_stats_load_leaves_data_panel_closed() {
         (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
+        try {
+            rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
 
-        rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
-
-        rule.waitForIdle()
-        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
-
-        (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(false)
+            rule.waitForIdle()
+            rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
+        } finally {
+            (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(false)
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.test.printToLog
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.rodbailey.covid.data.FakeRegions
+import com.rodbailey.covid.data.repo.CovidRepository
 import com.rodbailey.covid.data.repo.FakeCovidRepository
 import com.rodbailey.covid.domain.Region
 import com.rodbailey.covid.presentation.core.MainActivity
@@ -31,9 +32,11 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Inject
 
 /**
  * Instrumented test, which will execute on an Android device. These tests are tied to the
@@ -51,6 +54,14 @@ class MainUITest {
 
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var fakeCovidRepository: CovidRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
 
     @Test
     fun search_field_is_displayed_on_startup() {
@@ -187,6 +198,18 @@ class MainUITest {
 
             awaitComplete()
         }
+    }
+
+    @Test
+    fun failed_stats_load_leaves_data_panel_closed() {
+        (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
+
+        rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
+
+        rule.waitForIdle()
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
+
+        (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(false)
     }
 
     @Test

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -49,11 +49,11 @@ import javax.inject.Inject
 @HiltAndroidTest
 class MainUITest {
 
-    @get:Rule
-    val rule = createAndroidComposeRule<MainActivity>()
-
-    @get:Rule
+    @get:Rule(order = 0)
     var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val rule = createAndroidComposeRule<MainActivity>()
 
     @Inject
     lateinit var fakeCovidRepository: CovidRepository
@@ -202,14 +202,16 @@ class MainUITest {
 
     @Test
     fun failed_stats_load_leaves_data_panel_closed() {
-        (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
+        val fake = fakeCovidRepository as? FakeCovidRepository
+            ?: error("Test requires FakeCovidRepository but got ${fakeCovidRepository::class.java.name}")
+        fake.setAllMethodsThrowException(true)
         try {
             rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
 
             rule.waitForIdle()
             rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
         } finally {
-            (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(false)
+            fake.setAllMethodsThrowException(false)
         }
     }
 

--- a/test_gaps.md
+++ b/test_gaps.md
@@ -174,6 +174,7 @@ The highest-value additions would be: ~~**(1)** concurrent `refreshRegions()` mu
 - Click Australia shows Australia stats in data panel
 - Scroll to last region and click shows region stats in data panel
 - Tapping on data panel when showing hides the data panel
+- Failed stats load leaves data panel closed
 
 **Coverage:** Tests UI compose interactions, search filtering, data panel display and dismissal.
 


### PR DESCRIPTION
- [x] Fix HiltAndroidRule ordering (order=0) before Compose rule (order=1)
- [x] Apply safe cast with error message in `failed_stats_load_leaves_data_panel_closed`
- [x] Wrap test assertions in try/finally to ensure repository state is always reset