### PR TITLE
perf: improve LazyColumn item stability in MainScreen

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
@@ -137,10 +138,11 @@ fun MainScreenContent(
                         .testTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
                 ) {
                     when (val regions = uiState.matchingRegions) {
-                        is Success -> items(regions.data) { region ->
+                        is Success -> items(regions.data, key = { it.iso3Code }) { region ->
+                            val clickCallback = remember(region) { { onRegionClicked(region) } }
                             RegionSearchResultItem(
                                 region = region,
-                                clickCallback = { onRegionClicked(region) }
+                                clickCallback = clickCallback
                             )
                         }
                         else -> {}

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -139,7 +139,7 @@ fun MainScreenContent(
                 ) {
                     when (val regions = uiState.matchingRegions) {
                         is Success -> items(regions.data, key = { it.iso3Code }) { region ->
-                            val clickCallback = remember(region) { { onRegionClicked(region) } }
+                            val clickCallback = remember(region, onRegionClicked) { { onRegionClicked(region) } }
                             RegionSearchResultItem(
                                 region = region,
                                 clickCallback = clickCallback


### PR DESCRIPTION
## Summary
- Adds `key = { it.iso3Code }` to the `items()` call in `MainScreen` so Compose tracks list items by identity rather than position — prevents incorrect item reuse when the search filter reorders the list
- Wraps the `clickCallback` lambda in `remember(region)` so a new lambda instance is only created when the region itself changes, not on every recomposition of the `LazyColumn`

## Why
Without a stable key, filtering the search reorders items by position, which can cause state and animation artifacts. The inline lambda created a new object on every recomposition, preventing `RegionSearchResultItem` from skipping recomposition via Compose's smart recomposition mechanism.

## Test plan
- [ ] All instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] All unit tests pass (`./gradlew test`)
- [ ] Search filtering and region tapping work correctly on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)