### PR TITLE
refactor: reduce unnecessary Compose recompositions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true"
+        )
     }
     buildFeatures {
         compose = true
@@ -132,6 +136,7 @@ dependencies {
 
     // Enables " = viewModel()" access to view model in compose
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
 
     // Constraint layout for compose (used by data panel)
     implementation("androidx.constraintlayout:constraintlayout-compose:1.1.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,7 @@ android {
         jvmTarget = "1.8"
         freeCompilerArgs += listOf(
             "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true"
+            "plugin:androidx.compose.compiler.plugins.kotlin:strongSkipping=true"
         )
     }
     buildFeatures {

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -17,8 +17,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -63,7 +63,7 @@ fun MainScreen() {
         }
     }
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     MainScreenContent(
         uiState = uiState,
@@ -155,12 +155,8 @@ fun MainScreenContent(
                 // Clicking on the data panel collapses it.
                 AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
                     RegionDataPanel(
-                        title = (uiState.dataPanelUIState as? DataPanelOpenWithData)?.reportDataTitle?.asString()
-                            ?: "",
-                        reportData = (uiState.dataPanelUIState as? DataPanelOpenWithData)?.reportData
-                            ?: ReportData(),
-                        clickCallback = onDataPanelCollapsed,
-                        isLoading = uiState.dataPanelUIState is DataPanelOpenWithLoading
+C                        dataPanelUIState = uiState.dataPanelUIState,
+                        clickCallback = onDataPanelCollapsed
                     )
                 }
             }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -18,7 +18,10 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -52,14 +55,18 @@ fun MainScreen() {
     val context = LocalContext.current
     val viewModel: MainViewModel = viewModel()
 
-    // Error toast
-    LaunchedEffect(viewModel) {
-        viewModel.errorFlow.collect { uiText ->
-            Toast.makeText(
-                context,
-                uiText.asString(context),
-                Toast.LENGTH_LONG
-            ).show()
+    // Error toast — only shown while the UI is at least STARTED so toasts are never
+    // displayed in the background or silently dropped when the app is stopped.
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    LaunchedEffect(viewModel, lifecycle) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.errorFlow.collect { uiText ->
+                Toast.makeText(
+                    context,
+                    uiText.asString(context),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         }
     }
 

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -155,7 +155,7 @@ fun MainScreenContent(
                 // Clicking on the data panel collapses it.
                 AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
                     RegionDataPanel(
-C                        dataPanelUIState = uiState.dataPanelUIState,
+                        dataPanelUIState = uiState.dataPanelUIState,
                         clickCallback = onDataPanelCollapsed
                     )
                 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
@@ -21,26 +21,29 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rodbailey.covid.domain.ReportData
+import com.rodbailey.covid.presentation.MainViewModel
+import com.rodbailey.covid.presentation.core.UIText
 
 
 /**
  * Panel of covid statistics for a particular region. Shows confirmed, deaths, active and
  * fatality rate.
  *
- * @param title Name of the region - appears above data table
- * @param reportData Covid stats to put in the data table
+ * @param dataPanelUIState Current state of the data panel — loading or open with data
  * @param clickCallback Invoked when user clicks on this panel
- * @param isLoading true if the data to be displayed is still loading, so show a progress monitor
- * instead of the data table.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RegionDataPanel(
-    title: String,
-    reportData: ReportData,
-    clickCallback: () -> Unit,
-    isLoading: Boolean
+    dataPanelUIState: MainViewModel.DataPanelUIState,
+    clickCallback: () -> Unit
 ) {
+    val isLoading = dataPanelUIState is MainViewModel.DataPanelUIState.DataPanelOpenWithLoading
+    val title = (dataPanelUIState as? MainViewModel.DataPanelUIState.DataPanelOpenWithData)
+        ?.reportDataTitle?.asString() ?: ""
+    val reportData = (dataPanelUIState as? MainViewModel.DataPanelUIState.DataPanelOpenWithData)
+        ?.reportData ?: ReportData()
+
     Card(
         onClick = clickCallback, modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -86,22 +89,19 @@ fun RegionDataPanelPreviewNotLoading(
     @PreviewParameter(ReportDataParameterProvider::class) reportData: ReportData
 ) {
     RegionDataPanel(
-        title = ReportDataParameterProvider.title,
-        reportData = reportData,
-        clickCallback = {},
-        isLoading = false
+        dataPanelUIState = MainViewModel.DataPanelUIState.DataPanelOpenWithData(
+            reportDataTitle = UIText.DynamicString(ReportDataParameterProvider.title),
+            reportData = reportData
+        ),
+        clickCallback = {}
     )
 }
 
 @Preview
 @Composable
-fun RegionDataPanelPreviewLoading(
-    @PreviewParameter(ReportDataParameterProvider::class) reportData: ReportData
-) {
+fun RegionDataPanelPreviewLoading() {
     RegionDataPanel(
-        title = ReportDataParameterProvider.title,
-        reportData = reportData,
-        clickCallback = {},
-        isLoading = true
+        dataPanelUIState = MainViewModel.DataPanelUIState.DataPanelOpenWithLoading,
+        clickCallback = {}
     )
 }


### PR DESCRIPTION
- [x] Remove stray `C` character from `MainScreen.kt` `RegionDataPanel` call
- [x] Collect `errorFlow` with lifecycle awareness so errors are only handled while UI is STARTED