### PR TITLE
fix: Compose performance improvements

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -230,4 +230,39 @@ class MainUITest {
         rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
     }
 
+    @Test
+    fun data_panel_retains_content_during_exit_animation() {
+        // Open the data panel with known content
+        rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
+        rule.waitForIdle()
+
+        val expectedTitle = FakeRegions.GLOBAL_REGION.name
+        val globalStats = FakeRegions.GLOBAL_REGION_STATS
+
+        rule.onNodeWithTag(useUnmergedTree = true, testTag = MainScreenTag.TAG_CARD_TITLE.tag)
+            .assertTextEquals(expectedTitle)
+
+        // Freeze the Compose animation clock before triggering the close,
+        // so we can inspect the composition mid-animation.
+        rule.mainClock.autoAdvance = false
+
+        // Tap the panel — starts the AnimatedVisibility exit animation,
+        // but the frozen clock prevents it from advancing.
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).performClick()
+
+        // Step 50ms into the exit animation (well short of completion).
+        rule.mainClock.advanceTimeBy(50L)
+
+        // Title and stats should still be present — this is what lastVisibleState guarantees.
+        rule.onNodeWithTag(useUnmergedTree = true, testTag = MainScreenTag.TAG_CARD_TITLE.tag)
+            .assertTextEquals(expectedTitle)
+        rule.onNodeWithText(globalStats.confirmed.toString(), useUnmergedTree = true)
+            .assertExists()
+
+        // Let the animation finish and confirm the panel is fully removed.
+        rule.mainClock.autoAdvance = true
+        rule.waitForIdle()
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
+    }
+
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -117,7 +117,7 @@ class MainViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = UIState()
     )
 

--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -117,7 +117,7 @@ class MainViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
+        started = SharingStarted.WhileSubscribed(5_000),
         initialValue = UIState()
     )
 

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -22,7 +22,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
@@ -160,9 +162,16 @@ fun MainScreenContent(
 
                 // Data panel shows covid stats for current country or global.
                 // Clicking on the data panel collapses it.
+                // lastVisibleState retains the most recent non-closed state so that
+                // RegionDataPanel holds its content during the exit animation rather
+                // than blanking immediately when dataPanelUIState becomes DataPanelClosed.
+                var lastVisibleState by remember { mutableStateOf(uiState.dataPanelUIState) }
+                if (uiState.dataPanelUIState !is DataPanelClosed) {
+                    lastVisibleState = uiState.dataPanelUIState
+                }
                 AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
                     RegionDataPanel(
-                        dataPanelUIState = uiState.dataPanelUIState,
+                        dataPanelUIState = lastVisibleState,
                         clickCallback = onDataPanelCollapsed
                     )
                 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -166,8 +166,10 @@ fun MainScreenContent(
                 // RegionDataPanel holds its content during the exit animation rather
                 // than blanking immediately when dataPanelUIState becomes DataPanelClosed.
                 var lastVisibleState by remember { mutableStateOf(uiState.dataPanelUIState) }
-                if (uiState.dataPanelUIState !is DataPanelClosed) {
-                    lastVisibleState = uiState.dataPanelUIState
+                LaunchedEffect(uiState.dataPanelUIState) {
+                    if (uiState.dataPanelUIState !is DataPanelClosed) {
+                        lastVisibleState = uiState.dataPanelUIState
+                    }
                 }
                 AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
                     RegionDataPanel(


### PR DESCRIPTION
## Summary

- Add 5s stop timeout to `SharingStarted.WhileSubscribed()` so the upstream flow survives configuration changes (rotation etc.) without restarting and causing a spurious loading flash
- Retain data panel content during exit animation using `lastVisibleState` in `MainScreenContent`, so `RegionDataPanel` continues to display its title and stats while `AnimatedVisibility` fades out rather than blanking immediately

## Test plan

- [ ] Build passes (`./gradlew assembleDebug`)
- [ ] All unit tests pass (`./gradlew test`)
- [ ] All instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manually verify: open data panel, tap to close — content visible throughout the fade-out animation
- [ ] Manually verify: rotate device while data panel is open — no loading flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)