### PR TITLE
chore: upgrade Kotlin 1.9.25 → 2.3.20 with cascading dependency updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("jacoco")
@@ -41,19 +42,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:strongSkipping=true"
-        )
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+        }
     }
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
     }
     packaging {
         resources {
@@ -93,6 +89,10 @@ tasks.register<JacocoReport>("jacocoUnitTestReport") {
     })
 }
 
+configurations.all {
+    resolutionStrategy.force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
+}
+
 dependencies {
 
     implementation("androidx.core:core-ktx:1.13.1")
@@ -120,9 +120,9 @@ dependencies {
 
 //    def room_version = "2.6.1"
 
-    implementation("androidx.room:room-runtime:2.6.1")
-    ksp("androidx.room:room-compiler:2.6.1")
-    implementation("androidx.room:room-ktx:2.6.1")
+    implementation("androidx.room:room-runtime:2.7.0")
+    ksp("androidx.room:room-compiler:2.7.0")
+    implementation("androidx.room:room-ktx:2.7.0")
 
     // To use Kotlin annotation processing tool (kapt)
 //    kapt("androidx.room:room-compiler:2.6.1")
@@ -130,9 +130,11 @@ dependencies {
     //ksp "androidx.room:room-compiler:$room_version"
 
     // Hilt dependencies
-    implementation("com.google.dagger:hilt-android:2.51.1")
-    ksp("com.google.dagger:hilt-android-compiler:2.51.1")
-    androidTestImplementation("com.google.dagger:hilt-android-testing:2.51.1")
+    implementation("com.google.dagger:hilt-android:2.58")
+    ksp("com.google.dagger:hilt-android-compiler:2.58")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.58")
+    // Explicit kotlin-metadata-jvm override allows Hilt to process Kotlin 2.3 metadata
+    ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
 
     // Enables " = viewModel()" access to view model in compose
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.25" apply false
-    id("com.google.devtools.ksp") version "1.9.25-1.0.20" apply false
-    id("com.google.dagger.hilt.android") version "2.51.1" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.20" apply false
+    id("com.google.devtools.ksp") version "2.3.6" apply false
+    id("com.google.dagger.hilt.android") version "2.58" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Feb 06 10:06:35 AEDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Kotlin 1.9.25 → 2.3.20; AGP 8.2.2 → 8.13.2; Gradle 8.2 → 8.13
- KSP 1.9.25-1.0.20 → 2.3.6; Hilt 2.51.1 → 2.58; Room 2.6.1 → 2.7.0
- Added `org.jetbrains.kotlin.plugin.compose` plugin (Compose compiler now bundled with Kotlin 2.x)
- Migrated `kotlinOptions` to `kotlin { compilerOptions }` DSL; force-pinned `kotlin-metadata-jvm:2.3.20` for Hilt/KSP compatibility

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew test` — all unit tests pass
- [ ] `./gradlew connectedAndroidTest` — all 53 instrumented tests pass on emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)