### PR TITLE
chore: upgrade Compose BOM 2024.09.03 → 2026.03.01 with cascading updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.rodbailey.covid"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.rodbailey.covid"
@@ -97,16 +97,17 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
-    implementation("androidx.activity:activity-compose:1.9.3")
-    implementation(platform("androidx.compose:compose-bom:2024.09.03"))
+    implementation("androidx.activity:activity-compose:1.13.0")
+    implementation(platform("androidx.compose:compose-bom:2026.03.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-core")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.09.03"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2026.03.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
@@ -137,8 +138,8 @@ dependencies {
     ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
 
     // Enables " = viewModel()" access to view model in compose
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
 
     // Constraint layout for compose (used by data panel)
     implementation("androidx.constraintlayout:constraintlayout-compose:1.1.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,7 +96,7 @@ configurations.all {
 dependencies {
 
     implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
     implementation("androidx.activity:activity-compose:1.13.0")
     implementation(platform("androidx.compose:compose-bom:2026.03.01"))
     implementation("androidx.compose.ui:ui")

--- a/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
@@ -1,10 +1,9 @@
-@file:Suppress("DEPRECATION_ERROR")
-
 package com.rodbailey.covid.core.di
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -12,7 +11,7 @@ import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutinesTestRule(
-    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 ) : TestWatcher() {
 
     override fun starting(description: Description?) {

--- a/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
@@ -1,9 +1,10 @@
+@file:Suppress("DEPRECATION_ERROR")
+
 package com.rodbailey.covid.core.di
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -11,7 +12,7 @@ import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutinesTestRule(
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
 ) : TestWatcher() {
 
     override fun starting(description: Description?) {

--- a/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/core/di/CoroutinesTestRule.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION_ERROR")
+
 package com.rodbailey.covid.core.di
 
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +23,5 @@ class CoroutinesTestRule(
     override fun finished(description: Description?) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 }

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -58,6 +59,16 @@ class MainViewModelTest {
 
         // Have to construct viewModel manually here rather than inject. See comment above.
         viewModel = MainViewModel(fakeCovidRepository)
+    }
+
+    @After
+    fun tearDown() {
+        // Cancel viewModelScope to stop infinite MutableStateFlow collectors, preventing
+        // runTest's advanceUntilIdle() from hanging after the test body completes.
+        // onCleared() is protected so we invoke it via reflection.
+        val method = androidx.lifecycle.ViewModel::class.java.getDeclaredMethod("onCleared")
+        method.isAccessible = true
+        method.invoke(viewModel)
     }
 
     @Test

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -61,7 +61,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun sorted_region_list_loads_at_startup() = runTest {
+    fun sorted_region_list_loads_at_startup() = runTest(coroutinesTestRule.testDispatcher) {
         viewModel.uiState.test {
             // "asResult" flow automatically inserts "Loading" at flow start
             val item1 = awaitItem()
@@ -92,7 +92,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun data_panel_is_closed_at_startup() = runTest {
+    fun data_panel_is_closed_at_startup() = runTest(coroutinesTestRule.testDispatcher) {
         viewModel.uiState.test {
             val item1 = awaitItem()
             Assert.assertTrue(item1.dataPanelUIState is DataPanelClosed)
@@ -100,7 +100,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_of_brazil_matches_exactly_one_region() = runTest {
+    fun search_text_of_brazil_matches_exactly_one_region() = runTest(coroutinesTestRule.testDispatcher) {
         // Type "Brazil" into the search box
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("Brazil"))
 
@@ -116,7 +116,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun empty_search_text_matches_all_regions() = runTest {
+    fun empty_search_text_matches_all_regions() = runTest(coroutinesTestRule.testDispatcher) {
         // Type "" into the search box
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged(""))
 
@@ -131,7 +131,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun load_report_for_global_gives_global_data_in_data_panel() = runTest {
+    fun load_report_for_global_gives_global_data_in_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
         viewModel.uiState.test {
             val loading = awaitItem()
             val regionsEmpty = awaitItem()
@@ -159,7 +159,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_matching_is_case_insensitive() = runTest {
+    fun search_text_matching_is_case_insensitive() = runTest(coroutinesTestRule.testDispatcher) {
         // "BRAZIL" in upper case must still match "Brazil"
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("BRAZIL"))
 
@@ -174,7 +174,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_matches_substring_not_just_prefix() = runTest {
+    fun search_text_matches_substring_not_just_prefix() = runTest(coroutinesTestRule.testDispatcher) {
         // "istan" is a substring of "Afghanistan" and "Pakistan" but a prefix of neither.
         // Prefix-matching would return 0 results; substring-matching must return 2.
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("istan"))
@@ -192,7 +192,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun collapse_data_panel_intent_closes_open_data_panel() = runTest {
+    fun collapse_data_panel_intent_closes_open_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
         viewModel.uiState.test {
             // Skip initial emissions: loading, empty regions, and regions loaded
             skipItems(3)
@@ -212,7 +212,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun empty_country_stats_closes_data_panel_and_shows_error() = runTest {
+    fun empty_country_stats_closes_data_panel_and_shows_error() = runTest(coroutinesTestRule.testDispatcher) {
         (fakeCovidRepository as FakeCovidRepository).setRegionStatsEmpty(true)
         viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
         (fakeCovidRepository as FakeCovidRepository).setRegionStatsEmpty(false)
@@ -224,7 +224,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun stats_load_exception_closes_data_panel() = runTest {
+    fun stats_load_exception_closes_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
         viewModel.uiState.test {
             skipItems(3) // Result.Loading, Result.Success (empty), Result.Success (loaded)
 
@@ -244,7 +244,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun exception_from_api_when_loading_country_list_results_in_error_message() = runTest {
+    fun exception_from_api_when_loading_country_list_results_in_error_message() = runTest(coroutinesTestRule.testDispatcher) {
         // Flag must be set before ViewModel construction so the regions flow throws on collection
         (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(true)
         val errorViewModel = MainViewModel(fakeCovidRepository)
@@ -261,7 +261,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun exception_from_api_when_loading_country_stats_results_in_error_message() = runTest {
+    fun exception_from_api_when_loading_country_stats_results_in_error_message() = runTest(coroutinesTestRule.testDispatcher) {
         (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
         viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
 

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.rodbailey.covid.presentation.main
 
+import androidx.lifecycle.ViewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -17,8 +18,8 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -61,18 +62,29 @@ class MainViewModelTest {
         viewModel = MainViewModel(fakeCovidRepository)
     }
 
-    @After
-    fun tearDown() {
-        // Cancel viewModelScope to stop infinite MutableStateFlow collectors, preventing
-        // runTest's advanceUntilIdle() from hanging after the test body completes.
-        // onCleared() is protected so we invoke it via reflection.
-        val method = androidx.lifecycle.ViewModel::class.java.getDeclaredMethod("onCleared")
+    /**
+     * Runs [testBody] inside [runTest] and cancels [viewModel]'s viewModelScope in a finally
+     * block before runTest's advanceUntilIdle() runs. Without this, the infinite
+     * MutableStateFlow collectors in the ViewModel keep the scheduler busy and cause
+     * advanceUntilIdle() to hang.
+     */
+    private fun runViewModelTest(testBody: suspend TestScope.() -> Unit) =
+        runTest(coroutinesTestRule.testDispatcher) {
+            try {
+                testBody()
+            } finally {
+                clearViewModel(viewModel)
+            }
+        }
+
+    private fun clearViewModel(vm: ViewModel) {
+        val method = ViewModel::class.java.getDeclaredMethod("onCleared")
         method.isAccessible = true
-        method.invoke(viewModel)
+        method.invoke(vm)
     }
 
     @Test
-    fun sorted_region_list_loads_at_startup() = runTest(coroutinesTestRule.testDispatcher) {
+    fun sorted_region_list_loads_at_startup() = runViewModelTest {
         viewModel.uiState.test {
             // "asResult" flow automatically inserts "Loading" at flow start
             val item1 = awaitItem()
@@ -103,7 +115,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun data_panel_is_closed_at_startup() = runTest(coroutinesTestRule.testDispatcher) {
+    fun data_panel_is_closed_at_startup() = runViewModelTest {
         viewModel.uiState.test {
             val item1 = awaitItem()
             Assert.assertTrue(item1.dataPanelUIState is DataPanelClosed)
@@ -111,7 +123,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_of_brazil_matches_exactly_one_region() = runTest(coroutinesTestRule.testDispatcher) {
+    fun search_text_of_brazil_matches_exactly_one_region() = runViewModelTest {
         // Type "Brazil" into the search box
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("Brazil"))
 
@@ -127,7 +139,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun empty_search_text_matches_all_regions() = runTest(coroutinesTestRule.testDispatcher) {
+    fun empty_search_text_matches_all_regions() = runViewModelTest {
         // Type "" into the search box
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged(""))
 
@@ -142,7 +154,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun load_report_for_global_gives_global_data_in_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
+    fun load_report_for_global_gives_global_data_in_data_panel() = runViewModelTest {
         viewModel.uiState.test {
             val loading = awaitItem()
             val regionsEmpty = awaitItem()
@@ -170,7 +182,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_matching_is_case_insensitive() = runTest(coroutinesTestRule.testDispatcher) {
+    fun search_text_matching_is_case_insensitive() = runViewModelTest {
         // "BRAZIL" in upper case must still match "Brazil"
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("BRAZIL"))
 
@@ -185,7 +197,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun search_text_matches_substring_not_just_prefix() = runTest(coroutinesTestRule.testDispatcher) {
+    fun search_text_matches_substring_not_just_prefix() = runViewModelTest {
         // "istan" is a substring of "Afghanistan" and "Pakistan" but a prefix of neither.
         // Prefix-matching would return 0 results; substring-matching must return 2.
         viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged("istan"))
@@ -203,7 +215,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun collapse_data_panel_intent_closes_open_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
+    fun collapse_data_panel_intent_closes_open_data_panel() = runViewModelTest {
         viewModel.uiState.test {
             // Skip initial emissions: loading, empty regions, and regions loaded
             skipItems(3)
@@ -223,7 +235,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun empty_country_stats_closes_data_panel_and_shows_error() = runTest(coroutinesTestRule.testDispatcher) {
+    fun empty_country_stats_closes_data_panel_and_shows_error() = runViewModelTest {
         (fakeCovidRepository as FakeCovidRepository).setRegionStatsEmpty(true)
         viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
         (fakeCovidRepository as FakeCovidRepository).setRegionStatsEmpty(false)
@@ -235,7 +247,7 @@ class MainViewModelTest {
     }
 
     @Test
-    fun stats_load_exception_closes_data_panel() = runTest(coroutinesTestRule.testDispatcher) {
+    fun stats_load_exception_closes_data_panel() = runViewModelTest {
         viewModel.uiState.test {
             skipItems(3) // Result.Loading, Result.Success (empty), Result.Success (loaded)
 
@@ -255,24 +267,29 @@ class MainViewModelTest {
     }
 
     @Test
-    fun exception_from_api_when_loading_country_list_results_in_error_message() = runTest(coroutinesTestRule.testDispatcher) {
-        // Flag must be set before ViewModel construction so the regions flow throws on collection
-        (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(true)
-        val errorViewModel = MainViewModel(fakeCovidRepository)
-        (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(false)
+    fun exception_from_api_when_loading_country_list_results_in_error_message() =
+        runTest(coroutinesTestRule.testDispatcher) {
+            // Flag must be set before ViewModel construction so the regions flow throws on collection
+            (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(true)
+            val errorViewModel = MainViewModel(fakeCovidRepository)
+            (fakeCovidRepository as FakeCovidRepository).setRegionsThrowException(false)
 
-        // uiState uses WhileSubscribed — must have an active subscriber to trigger flow collection
-        val collectorJob = backgroundScope.launch { errorViewModel.uiState.collect {} }
+            try {
+                // uiState uses WhileSubscribed — must have an active subscriber to trigger flow collection
+                val collectorJob = backgroundScope.launch { errorViewModel.uiState.collect {} }
 
-        errorViewModel.errorFlow.test {
-            val result = awaitItem()
-            Assert.assertEquals(context.getString(R.string.failed_to_load_country_list), result.asString(context))
+                errorViewModel.errorFlow.test {
+                    val result = awaitItem()
+                    Assert.assertEquals(context.getString(R.string.failed_to_load_country_list), result.asString(context))
+                }
+                collectorJob.cancel()
+            } finally {
+                clearViewModel(errorViewModel)
+            }
         }
-        collectorJob.cancel()
-    }
 
     @Test
-    fun exception_from_api_when_loading_country_stats_results_in_error_message() = runTest(coroutinesTestRule.testDispatcher) {
+    fun exception_from_api_when_loading_country_stats_results_in_error_message() = runViewModelTest {
         (fakeCovidRepository as FakeCovidRepository).setAllMethodsThrowException(true)
         viewModel.processIntent(MainViewModel.MainIntent.LoadReportDataForGlobal)
 


### PR DESCRIPTION
- [x] Upgrade Compose BOM and related dependencies
- [x] Align `lifecycle-runtime-ktx` to `2.10.0` (matching `lifecycle-viewmodel-compose` and `lifecycle-runtime-compose`)
- [x] Migrate `CoroutinesTestRule` from deprecated `TestCoroutineDispatcher` to `UnconfinedTestDispatcher`/`TestDispatcher` — removes `@file:Suppress("DEPRECATION_ERROR")`