### PR TITLE
fix: migrate empty_search_text_matches_all_regions to subscribe-first pattern

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -118,19 +118,18 @@ class MainViewModelTest {
         }
 
     @Test
-    fun empty_search_text_matches_all_regions() = runTest {
-        // Type "" into the search box
-        viewModel.processIntent(MainViewModel.MainIntent.OnSearchTextChanged(""))
-
-        viewModel.uiState.test {
-            val loading = awaitItem()
-            val empty = awaitItem()
-            val result = awaitItem()
-            // Confirm region list contains all regions
-            val resultAsSuccess = result.matchingRegions as Result.Success
-            Assert.assertEquals(FakeRegions.REGIONS.size, resultAsSuccess.data.size)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun empty_search_text_matches_all_regions() =
+        runTest(UnconfinedTestDispatcher()) {
+            viewModel.uiState.test {
+                skipItems(2) // Skip initial emissions: loading and empty regions
+                // Empty search text is the default — no intent needed.
+                // The third emission is the full unfiltered region list.
+                val result = awaitItem()
+                val resultAsSuccess = result.matchingRegions as Result.Success
+                Assert.assertEquals(FakeRegions.REGIONS.size, resultAsSuccess.data.size)
+            }
         }
-    }
 
     @Test
     fun load_report_for_global_gives_global_data_in_data_panel() = runTest {


### PR DESCRIPTION
## Summary

Rewrites `empty_search_text_matches_all_regions` to match the pattern used by all other search-text tests in `MainViewModelTest`.

## Change

**Before:** fired `OnSearchTextChanged("")` before subscribing to `uiState`, then awaited three items with named variables.

**After:** `runTest(UnconfinedTestDispatcher())`, subscribe to `uiState` first, `skipItems(2)` for the two boilerplate initial emissions (Loading, empty Success), then assert on the third emission (full unfiltered region list).

The `processIntent(OnSearchTextChanged(""))` call is removed — setting search text to `""` is a no-op since that is the default value, and waiting for a fourth emission after firing it would cause a timeout.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)