### PR TITLE
feat: add cache statistics screen (triple-tap, summary table, bar chart)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("jacoco")
+    id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {
@@ -149,4 +150,9 @@ dependencies {
 
     // Turbine - for testing Flows
     androidTestImplementation("app.cash.turbine:turbine:1.1.0")
+
+    // Compose Navigation + type-safe routes
+    implementation("androidx.navigation:navigation-compose:2.8.4")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 }

--- a/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
@@ -1,6 +1,7 @@
 package com.rodbailey.covid.data.repo
 
 import com.rodbailey.covid.data.FakeRegions
+import com.rodbailey.covid.data.repo.CacheEntry
 import com.rodbailey.covid.domain.Region
 import com.rodbailey.covid.domain.ReportData
 import com.rodbailey.covid.domain.toRegionStats
@@ -74,5 +75,14 @@ class FakeCovidRepository() : CovidRepository {
     fun setRegionsThrowException(value: Boolean) {
         regionsThrowException = value
     }
+
+    /** The list returned by [getCacheEntriesStream]. Defaults to empty. */
+    private var cacheEntries: List<CacheEntry> = emptyList()
+
+    fun setCacheEntries(entries: List<CacheEntry>) {
+        cacheEntries = entries
+    }
+
+    override fun getCacheEntriesStream(): Flow<List<CacheEntry>> = flowOf(cacheEntries)
 
 }

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
@@ -1,0 +1,156 @@
+package com.rodbailey.covid.presentation.cachestats
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import app.cash.turbine.test
+import com.rodbailey.covid.data.repo.CacheEntry
+import com.rodbailey.covid.data.repo.CovidRepository
+import com.rodbailey.covid.data.repo.FakeCovidRepository
+import com.rodbailey.covid.presentation.Result
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Instrumented tests for [CacheStatsViewModel] backed by [FakeCovidRepository].
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+@HiltAndroidTest
+class CacheStatsViewModelTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var fakeCovidRepository: CovidRepository
+
+    lateinit var viewModel: CacheStatsViewModel
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        // Reset cache entries to empty before each test
+        (fakeCovidRepository as FakeCovidRepository).setCacheEntries(emptyList())
+        viewModel = CacheStatsViewModel(fakeCovidRepository)
+    }
+
+    // -------------------------------------------------------------------------
+    // Initial state
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initial_state_is_loading() = runTest {
+        viewModel.uiState.test {
+            val first = awaitItem()
+            Assert.assertTrue(
+                "Expected Result.Loading for initial state, got ${first.entries}",
+                first.entries is Result.Loading
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty cache
+    // -------------------------------------------------------------------------
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun empty_cache_emits_success_with_empty_list() =
+        runTest(UnconfinedTestDispatcher()) {
+            // FakeCovidRepository already configured with empty list in @Before
+            viewModel.uiState.test {
+                skipItems(1) // skip Result.Loading
+                val state = awaitItem()
+                Assert.assertTrue(
+                    "Expected Result.Success, got ${state.entries}",
+                    state.entries is Result.Success
+                )
+                val entries = (state.entries as Result.Success).data
+                Assert.assertTrue("Expected empty list", entries.isEmpty())
+            }
+        }
+
+    // -------------------------------------------------------------------------
+    // Cache with entries
+    // -------------------------------------------------------------------------
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun cache_with_entries_emits_success_with_correct_count() =
+        runTest(UnconfinedTestDispatcher()) {
+            val testEntries = listOf(
+                CacheEntry("AFG", 60_000L),
+                CacheEntry("AUS", 120_000L),
+                CacheEntry("BRA", 180_000L),
+            )
+            (fakeCovidRepository as FakeCovidRepository).setCacheEntries(testEntries)
+            // Rebuild ViewModel so it picks up the new entries
+            viewModel = CacheStatsViewModel(fakeCovidRepository)
+
+            viewModel.uiState.test {
+                skipItems(1) // skip Result.Loading
+                val state = awaitItem()
+                Assert.assertTrue(
+                    "Expected Result.Success, got ${state.entries}",
+                    state.entries is Result.Success
+                )
+                val entries = (state.entries as Result.Success).data
+                Assert.assertEquals("Expected 3 entries", 3, entries.size)
+            }
+        }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun cache_entries_preserve_iso3_codes_and_age_values() =
+        runTest(UnconfinedTestDispatcher()) {
+            val testEntries = listOf(
+                CacheEntry("DEU", 300_000L),
+                CacheEntry("FRA", 600_000L),
+            )
+            (fakeCovidRepository as FakeCovidRepository).setCacheEntries(testEntries)
+            viewModel = CacheStatsViewModel(fakeCovidRepository)
+
+            viewModel.uiState.test {
+                skipItems(1) // skip Result.Loading
+                val state = awaitItem()
+                val entries = (state.entries as Result.Success).data
+
+                Assert.assertEquals("DEU", entries[0].iso3Code)
+                Assert.assertEquals(300_000L, entries[0].ageMillis)
+                Assert.assertEquals("FRA", entries[1].iso3Code)
+                Assert.assertEquals(600_000L, entries[1].ageMillis)
+            }
+        }
+
+    // -------------------------------------------------------------------------
+    // Single entry edge case
+    // -------------------------------------------------------------------------
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun single_cache_entry_emits_success_with_one_entry() =
+        runTest(UnconfinedTestDispatcher()) {
+            (fakeCovidRepository as FakeCovidRepository).setCacheEntries(
+                listOf(CacheEntry("USA", 45_000L))
+            )
+            viewModel = CacheStatsViewModel(fakeCovidRepository)
+
+            viewModel.uiState.test {
+                skipItems(1) // skip Result.Loading
+                val state = awaitItem()
+                val entries = (state.entries as Result.Success).data
+                Assert.assertEquals(1, entries.size)
+                Assert.assertEquals("USA", entries[0].iso3Code)
+                Assert.assertEquals(45_000L, entries[0].ageMillis)
+            }
+        }
+}

--- a/app/src/main/java/com/rodbailey/covid/core/di/DatabaseModule.kt
+++ b/app/src/main/java/com/rodbailey/covid/core/di/DatabaseModule.kt
@@ -23,7 +23,7 @@ object DatabaseModule {
             ctx,
             AppDatabase::class.java,
             "covid"
-        ).build()
+        ).fallbackToDestructiveMigration(true).build()
     }
 
     @Singleton

--- a/app/src/main/java/com/rodbailey/covid/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/AppDatabase.kt
@@ -3,8 +3,7 @@ package com.rodbailey.covid.data.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [RegionEntity::class, RegionStatsEntity::class], version = 1,
-)
+@Database(entities = [RegionEntity::class, RegionStatsEntity::class], version = 2)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun regionDao() : RegionDao
     abstract fun regionStatsDao() : RegionStatsDao

--- a/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsDao.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsDao.kt
@@ -12,4 +12,7 @@ interface RegionStatsDao {
 
     @Query("select * from stats where iso3code = :iso3code")
     suspend fun getRegionStats(iso3code: String): List<RegionStatsEntity>
+
+    @Query("SELECT * FROM stats ORDER BY iso3code COLLATE NOCASE ASC")
+    fun getAllStatsStream(): Flow<List<RegionStatsEntity>>
 }

--- a/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsEntity.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsEntity.kt
@@ -27,7 +27,11 @@ data class RegionStatsEntity(
     val active: Long,
 
     @ColumnInfo(name = "fatalityRate")
-    val fatalityRate: Float
+    val fatalityRate: Float,
+
+    /** Milliseconds since epoch when this row was inserted into the cache. */
+    @ColumnInfo(name = "timestamp")
+    val timestamp: Long = 0L
 )
 
 fun RegionStatsEntity.toRegionStats() =

--- a/app/src/main/java/com/rodbailey/covid/data/repo/CacheEntry.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/CacheEntry.kt
@@ -1,0 +1,15 @@
+package com.rodbailey.covid.data.repo
+
+/**
+ * Represents one cached region stats row as seen by the presentation layer.
+ *
+ * @param iso3Code ISO3 country code for this entry.
+ * @param ageMillis Age of this cache entry in milliseconds (currentTimeMillis - timestamp).
+ */
+data class CacheEntry(
+    val iso3Code: String,
+    val ageMillis: Long
+)
+
+/** Approximate SQLite storage occupied per stats row (used for total-bytes summary). */
+const val BYTES_PER_STATS_ROW = 70

--- a/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
@@ -19,4 +19,10 @@ interface CovidRepository {
      */
     fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>>
 
+    /**
+     * @return Hot flow of all cached region stats entries, sorted by ISO3 code
+     * (case-insensitive). Emits a new list whenever the cache changes.
+     */
+    fun getCacheEntriesStream(): Flow<List<CacheEntry>>
+
 }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -33,6 +33,7 @@ class DefaultCovidRepository(
             if (dbStats.isEmpty()) {
                 val report = covidApi.getReport(codeToApiQueryParam(code))
                 val entity = report.data.toRegionStatsEntity(code.chars)
+                    .copy(timestamp = System.currentTimeMillis())
                 regionStatsDao.insert(entity)
                 listOf(entity.toRegionStats())
             } else {
@@ -40,6 +41,13 @@ class DefaultCovidRepository(
             }
         )
     }
+
+    override fun getCacheEntriesStream(): Flow<List<CacheEntry>> =
+        regionStatsDao.getAllStatsStream().map { entities ->
+            val now = System.currentTimeMillis()
+            entities.map { CacheEntry(iso3Code = it.iso3code, ageMillis = now - it.timestamp) }
+            // DAO returns rows ORDER BY iso3code COLLATE NOCASE ASC — no in-memory sort needed
+        }
 
     private fun codeToApiQueryParam(code: RegionCode): String? {
         return if (code is GlobalCode) {

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -1,0 +1,235 @@
+package com.rodbailey.covid.presentation.cachestats
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.rodbailey.covid.data.repo.BYTES_PER_STATS_ROW
+import com.rodbailey.covid.data.repo.CacheEntry
+import com.rodbailey.covid.presentation.Result
+import com.rodbailey.covid.presentation.theme.CovidTheme
+
+// ---------------------------------------------------------------------------
+// Age formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts [millis] to a human-readable age string.
+ * Examples: "45s", "3m 12s", "2h 05m", "1d 14h".
+ */
+fun formatAge(millis: Long): String {
+    if (millis <= 0L) return "0s"
+    val totalSeconds = millis / 1000L
+    val days = totalSeconds / 86400L
+    val hours = (totalSeconds % 86400L) / 3600L
+    val minutes = (totalSeconds % 3600L) / 60L
+    val seconds = totalSeconds % 60L
+    return when {
+        days > 0 -> "${days}d ${hours}h"
+        hours > 0 -> "${hours}h ${minutes.toString().padStart(2, '0')}m"
+        minutes > 0 -> "${minutes}m ${seconds.toString().padStart(2, '0')}s"
+        else -> "${seconds}s"
+    }
+}
+
+private fun formatBytes(bytes: Int): String = when {
+    bytes >= 1024 -> "${bytes / 1024} KB"
+    else -> "$bytes B"
+}
+
+// ---------------------------------------------------------------------------
+// Root composable (stateful)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateful entry point for the cache statistics screen. Owns the [CacheStatsViewModel]
+ * and delegates rendering to [CacheStatsScreenContent].
+ *
+ * @param onDismiss Invoked when the user navigates back (back button or system gesture).
+ */
+@Composable
+fun CacheStatsScreen(
+    onDismiss: () -> Unit,
+    viewModel: CacheStatsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val entries = (uiState.entries as? Result.Success)?.data ?: emptyList()
+
+    CacheStatsScreenContent(
+        entries = entries,
+        onDismiss = onDismiss
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Content composable (stateless)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateless content for the cache statistics screen.
+ *
+ * Layout:
+ * - [CacheStatsSummaryTable] pinned below the top bar (never scrolls).
+ * - [HorizontalBarChart] fills the remaining height with its own independent scroll.
+ *
+ * @param entries Cache entries sorted by ISO3 code (caller responsible for ordering).
+ * @param onDismiss Invoked when the user navigates back.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CacheStatsScreenContent(
+    entries: List<CacheEntry>,
+    onDismiss: () -> Unit
+) {
+    BackHandler(onBack = onDismiss)
+
+    CovidTheme {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Cache Statistics") },
+                    navigationIcon = {
+                        IconButton(onClick = onDismiss) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back"
+                            )
+                        }
+                    }
+                )
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                // Summary table — fixed, not scrollable
+                CacheStatsSummaryTable(
+                    entries = entries,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Bar chart — fills remaining height; LazyColumn inside scrolls independently
+                HorizontalBarChart(
+                    entries = entries.map {
+                        BarChartEntry(label = it.iso3Code, value = it.ageMillis.toFloat())
+                    },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    valueFormatter = { formatAge(it.toLong()) }
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summary table
+// ---------------------------------------------------------------------------
+
+@Composable
+fun CacheStatsSummaryTable(
+    entries: List<CacheEntry>,
+    modifier: Modifier = Modifier
+) {
+    val count = entries.size
+    val totalBytes = count * BYTES_PER_STATS_ROW
+    val avgAgeMillis = if (entries.isEmpty()) 0L else entries.map { it.ageMillis }.average().toLong()
+    val oldest = entries.maxByOrNull { it.ageMillis }
+    val youngest = entries.minByOrNull { it.ageMillis }
+
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            SummaryRow(label = "Entries", value = count.toString())
+            SummaryRow(label = "Total size", value = formatBytes(totalBytes))
+            SummaryRow(label = "Average age", value = formatAge(avgAgeMillis))
+            SummaryRow(
+                label = "Oldest entry",
+                value = if (oldest != null) "${oldest.iso3Code} — ${formatAge(oldest.ageMillis)}" else "—"
+            )
+            SummaryRow(
+                label = "Youngest entry",
+                value = if (youngest != null) "${youngest.iso3Code} — ${formatAge(youngest.ageMillis)}" else "—"
+            )
+        }
+    }
+}
+
+@Composable
+private fun SummaryRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Previews
+// ---------------------------------------------------------------------------
+
+private val previewEntries = listOf(
+    CacheEntry("AFG", 2_478_000L),
+    CacheEntry("AUS", 1_620_000L),
+    CacheEntry("BRA",   660_000L),
+    CacheEntry("CAN", 1_440_000L),
+    CacheEntry("DEU",   300_000L),
+    CacheEntry("EGY", 2_330_000L),
+    CacheEntry("FRA",   900_000L),
+)
+
+@Preview(showBackground = true, name = "Cache Stats — with data")
+@Composable
+private fun PreviewCacheStatsWithData() {
+    CacheStatsScreenContent(entries = previewEntries, onDismiss = {})
+}
+
+@Preview(showBackground = true, name = "Cache Stats — empty cache")
+@Composable
+private fun PreviewCacheStatsEmpty() {
+    CacheStatsScreenContent(entries = emptyList(), onDismiss = {})
+}

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
@@ -1,0 +1,34 @@
+package com.rodbailey.covid.presentation.cachestats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rodbailey.covid.data.repo.CacheEntry
+import com.rodbailey.covid.data.repo.CovidRepository
+import com.rodbailey.covid.presentation.Result
+import com.rodbailey.covid.presentation.asResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class CacheStatsViewModel @Inject constructor(
+    repo: CovidRepository
+) : ViewModel() {
+
+    data class UIState(
+        val entries: Result<List<CacheEntry>> = Result.Loading
+    )
+
+    val uiState: StateFlow<UIState> =
+        repo.getCacheEntriesStream()
+            .asResult()
+            .map { UIState(entries = it) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(),
+                initialValue = UIState()
+            )
+}

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/HorizontalBarChart.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/HorizontalBarChart.kt
@@ -1,0 +1,132 @@
+package com.rodbailey.covid.presentation.cachestats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * One entry in a [HorizontalBarChart].
+ *
+ * @param label Text shown to the left of the bar (e.g. a country code).
+ * @param value Numeric value that determines bar length relative to the maximum entry.
+ */
+data class BarChartEntry(val label: String, val value: Float)
+
+private val LABEL_WIDTH = 56.dp
+private val BAR_HEIGHT = 20.dp
+private val ROW_SPACING = 6.dp
+private val VALUE_TEXT_PADDING = 6.dp
+
+/**
+ * Reusable horizontal bar chart. Each entry is rendered as a labelled bar whose length
+ * is proportional to [BarChartEntry.value] relative to the maximum value in [entries].
+ *
+ * The chart is internally scrollable via [LazyColumn] — callers should **not** place it
+ * inside another vertical scroll container.
+ *
+ * @param entries Data to display. Caller is responsible for ordering.
+ * @param modifier Modifier applied to the [LazyColumn] root.
+ * @param valueFormatter Converts a [BarChartEntry.value] to the label shown beside the bar.
+ *   Defaults to an empty string (no value label).
+ */
+@Composable
+fun HorizontalBarChart(
+    entries: List<BarChartEntry>,
+    modifier: Modifier = Modifier,
+    valueFormatter: (Float) -> String = { "" }
+) {
+    val maxValue = entries.maxOfOrNull { it.value }?.takeIf { it > 0f } ?: 1f
+
+    LazyColumn(modifier = modifier) {
+        items(entries, key = { it.label }) { entry ->
+            HorizontalBarRow(
+                entry = entry,
+                fraction = entry.value / maxValue,
+                valueFormatter = valueFormatter
+            )
+            Spacer(modifier = Modifier.height(ROW_SPACING))
+        }
+    }
+}
+
+@Composable
+private fun HorizontalBarRow(
+    entry: BarChartEntry,
+    fraction: Float,
+    valueFormatter: (Float) -> String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BAR_HEIGHT),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Fixed-width label column so all bars start at the same X position
+        Text(
+            text = entry.label,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.width(LABEL_WIDTH),
+            maxLines = 1
+        )
+
+        // Bar — fills remaining width proportionally
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(fraction = fraction.coerceIn(0f, 1f))
+                    .fillMaxHeight()
+                    .background(MaterialTheme.colorScheme.primary)
+            )
+        }
+
+        // Value text to the right of the bar
+        val valueText = valueFormatter(entry.value)
+        if (valueText.isNotEmpty()) {
+            Text(
+                text = valueText,
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 11.sp),
+                modifier = Modifier.padding(start = VALUE_TEXT_PADDING),
+                maxLines = 1
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Previews
+// ---------------------------------------------------------------------------
+
+@Preview(showBackground = true, name = "HorizontalBarChart")
+@Composable
+private fun PreviewHorizontalBarChart() {
+    HorizontalBarChart(
+        entries = listOf(
+            BarChartEntry("AFG", 2478000f),
+            BarChartEntry("AUS", 1620000f),
+            BarChartEntry("BRA", 660000f),
+            BarChartEntry("CAN", 1440000f),
+            BarChartEntry("DEU", 300000f),
+        ),
+        valueFormatter = { formatAge(it.toLong()) }
+    )
+}

--- a/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
@@ -3,7 +3,13 @@ package com.rodbailey.covid.presentation.core
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.rodbailey.covid.presentation.cachestats.CacheStatsScreen
 import com.rodbailey.covid.presentation.main.MainScreen
+import com.rodbailey.covid.presentation.navigation.CacheStatsRoute
+import com.rodbailey.covid.presentation.navigation.MainRoute
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -11,7 +17,19 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MainScreen()
+            val navController = rememberNavController()
+            NavHost(navController = navController, startDestination = MainRoute) {
+                composable<MainRoute> {
+                    MainScreen(
+                        onNavigateToCacheStats = { navController.navigate(CacheStatsRoute) }
+                    )
+                }
+                composable<CacheStatsRoute> {
+                    CacheStatsScreen(
+                        onDismiss = { navController.popBackStack() }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -22,16 +22,21 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.rodbailey.covid.R
 import com.rodbailey.covid.domain.Region
 import com.rodbailey.covid.domain.ReportData
@@ -53,9 +58,9 @@ import com.rodbailey.covid.presentation.theme.CovidTheme
  * collects state, and delegates rendering to [MainScreenContent].
  */
 @Composable
-fun MainScreen() {
+fun MainScreen(onNavigateToCacheStats: () -> Unit = {}) {
     val context = LocalContext.current
-    val viewModel: MainViewModel = viewModel()
+    val viewModel: MainViewModel = hiltViewModel()
 
     // Error toast — only shown while the UI is at least STARTED so toasts are never
     // displayed in the background or silently dropped when the app is stopped.
@@ -83,9 +88,13 @@ fun MainScreen() {
                 LoadReportDataForRegion(UIText.DynamicString(region.name), region.toRegionCode())
             )
         },
-        onDataPanelCollapsed = { viewModel.processIntent(MainViewModel.MainIntent.CollapseDataPanel) }
+        onDataPanelCollapsed = { viewModel.processIntent(MainViewModel.MainIntent.CollapseDataPanel) },
+        onTripleTap = onNavigateToCacheStats
     )
 }
+
+/** Time window in milliseconds within which 3 taps must occur to count as a triple-tap. */
+private const val TRIPLE_TAP_TIMEOUT_MS = 500L
 
 /**
  * Stateless content for the main screen. Receives all state and callbacks as parameters,
@@ -96,15 +105,41 @@ fun MainScreen() {
  * @param onGlobalClicked Invoked when the global stats icon is tapped
  * @param onRegionClicked Invoked when a region list item is tapped
  * @param onDataPanelCollapsed Invoked when the data panel is tapped to collapse it
+ * @param onTripleTap Invoked when three taps are detected within [TRIPLE_TAP_TIMEOUT_MS]
  */
+
 @Composable
 fun MainScreenContent(
     uiState: MainViewModel.UIState,
     onSearchTextChanged: (String) -> Unit,
     onGlobalClicked: () -> Unit,
     onRegionClicked: (Region) -> Unit,
-    onDataPanelCollapsed: () -> Unit
+    onDataPanelCollapsed: () -> Unit,
+    onTripleTap: () -> Unit = {}
 ) {
+    // Triple-tap state tracked at the composable level so it survives recomposition.
+    var tapCount by remember { mutableIntStateOf(0) }
+    var lastTapTime by remember { mutableLongStateOf(0L) }
+
+    // Observe pointer presses using PointerEventPass.Initial so child elements (search
+    // field, list items, data panel) still receive all their own touch events unaffected.
+    val tripleTapModifier = Modifier.pointerInput(onTripleTap) {
+        awaitPointerEventScope {
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                if (event.type == PointerEventType.Press) {
+                    val now = System.currentTimeMillis()
+                    tapCount = if (now - lastTapTime > TRIPLE_TAP_TIMEOUT_MS) 1 else tapCount + 1
+                    lastTapTime = now
+                    if (tapCount >= 3) {
+                        tapCount = 0
+                        onTripleTap()
+                    }
+                }
+            }
+        }
+    }
+
     CovidTheme {
         // A surface container using the 'background' color from the theme
         Surface(
@@ -112,7 +147,9 @@ fun MainScreenContent(
             color = MaterialTheme.colorScheme.background
         ) {
             Column(
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(tripleTapModifier)
             ) {
                 // Search text field with global icon at right
                 TextField(

--- a/app/src/main/java/com/rodbailey/covid/presentation/navigation/Routes.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/navigation/Routes.kt
@@ -1,0 +1,9 @@
+package com.rodbailey.covid.presentation.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object MainRoute
+
+@Serializable
+data object CacheStatsRoute

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.20" apply false
     id("com.google.devtools.ksp") version "2.3.6" apply false
     id("com.google.dagger.hilt.android") version "2.58" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.20" apply false
 }


### PR DESCRIPTION
## Summary

Adds a hidden developer screen that displays cache statistics for the region COVID stats stored in Room. The screen is revealed by triple-tapping the main screen background.

## Changes

### Database
- Added `timestamp: Long` to `RegionStatsEntity` — stamped at insert time
- Bumped DB version 1 → 2 with `fallbackToDestructiveMigration` (cached rows without timestamps are wiped on first upgrade; cache repopulates on demand)
- Added `RegionStatsDao.getAllStatsStream()` ordered by ISO3 code

### Domain / Repository
- New `CacheEntry(iso3Code, ageMillis)` domain model + `BYTES_PER_STATS_ROW` constant
- New `CovidRepository.getCacheEntriesStream()` interface method + `DefaultCovidRepository` implementation

### Presentation
- `CacheStatsViewModel` — Hilt ViewModel exposing `StateFlow<UIState>` via `asResult()`
- `HorizontalBarChart` — reusable composable; bars proportional to value, internally scrollable via `LazyColumn`
- `CacheStatsScreen` — pinned summary table (entry count, total size, average/oldest/youngest age) + independently scrollable bar chart
- Type-safe Compose Navigation: `MainRoute` / `CacheStatsRoute` with `NavHost` in `MainActivity`
- Triple-tap gesture on `MainScreen` background using `PointerEventPass.Initial` (non-consuming, so child taps still work)

### Tests
- `CacheStatsViewModelTest` — 5 instrumented tests covering initial loading state, empty cache, multiple entries, field value preservation, and single-entry edge case
- `FakeCovidRepository` extended with `setCacheEntries()` for test configuration

## Verification
- All 58 instrumented tests pass
- `./gradlew assembleDebug` clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)