### PR TITLE
feat: cache statistics screen improvements

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.rodbailey.covid.presentation.cachestats
 
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import app.cash.turbine.test
@@ -40,7 +41,7 @@ class CacheStatsViewModelTest {
         hiltRule.inject()
         // Reset cache entries to empty before each test
         (fakeCovidRepository as FakeCovidRepository).setCacheEntries(emptyList())
-        viewModel = CacheStatsViewModel(fakeCovidRepository)
+        viewModel = CacheStatsViewModel(fakeCovidRepository, ApplicationProvider.getApplicationContext())
     }
 
     // -------------------------------------------------------------------------
@@ -94,7 +95,7 @@ class CacheStatsViewModelTest {
             )
             (fakeCovidRepository as FakeCovidRepository).setCacheEntries(testEntries)
             // Rebuild ViewModel so it picks up the new entries
-            viewModel = CacheStatsViewModel(fakeCovidRepository)
+            viewModel = CacheStatsViewModel(fakeCovidRepository, ApplicationProvider.getApplicationContext())
 
             viewModel.uiState.test {
                 skipItems(1) // skip Result.Loading
@@ -117,7 +118,7 @@ class CacheStatsViewModelTest {
                 CacheEntry("FRA", 600_000L),
             )
             (fakeCovidRepository as FakeCovidRepository).setCacheEntries(testEntries)
-            viewModel = CacheStatsViewModel(fakeCovidRepository)
+            viewModel = CacheStatsViewModel(fakeCovidRepository, ApplicationProvider.getApplicationContext())
 
             viewModel.uiState.test {
                 skipItems(1) // skip Result.Loading
@@ -142,7 +143,7 @@ class CacheStatsViewModelTest {
             (fakeCovidRepository as FakeCovidRepository).setCacheEntries(
                 listOf(CacheEntry("USA", 45_000L))
             )
-            viewModel = CacheStatsViewModel(fakeCovidRepository)
+            viewModel = CacheStatsViewModel(fakeCovidRepository, ApplicationProvider.getApplicationContext())
 
             viewModel.uiState.test {
                 skipItems(1) // skip Result.Loading

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -12,15 +12,23 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,7 +46,7 @@ import com.rodbailey.covid.presentation.theme.CovidTheme
 
 /**
  * Converts [millis] to a human-readable age string.
- * Examples: "45s", "3m 12s", "2h 05m", "1d 14h".
+ * Examples: "45s", "3m 12s", "2h 05m 30s", "1d 14h 30m 05s".
  */
 fun formatAge(millis: Long): String {
     if (millis <= 0L) return "0s"
@@ -58,6 +66,25 @@ fun formatAge(millis: Long): String {
 private fun formatBytes(bytes: Int): String = when {
     bytes >= 1024 -> "${bytes / 1024} KB"
     else -> "$bytes B"
+}
+
+// ---------------------------------------------------------------------------
+// Sort
+// ---------------------------------------------------------------------------
+
+/** The four orderings available to the user via the sort control. */
+enum class SortOption(val label: String) {
+    ISO_CODE_ASC("ISO Code (up)"),
+    ISO_CODE_DESC("ISO Code (down)"),
+    AGE_ASC("Age (up)"),
+    AGE_DESC("Age (down)")
+}
+
+private fun List<CacheEntry>.applySortOption(option: SortOption): List<CacheEntry> = when (option) {
+    SortOption.ISO_CODE_ASC  -> sortedBy { it.iso3Code }
+    SortOption.ISO_CODE_DESC -> sortedByDescending { it.iso3Code }
+    SortOption.AGE_ASC       -> sortedBy { it.ageMillis }
+    SortOption.AGE_DESC      -> sortedByDescending { it.ageMillis }
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +108,8 @@ fun CacheStatsScreen(
 
     CacheStatsScreenContent(
         entries = entries,
+        sortOption = uiState.sortOption,
+        onSortOptionSelected = viewModel::setSortOption,
         onDismiss = onDismiss
     )
 }
@@ -92,20 +121,27 @@ fun CacheStatsScreen(
 /**
  * Stateless content for the cache statistics screen.
  *
- * Layout:
- * - [CacheStatsSummaryTable] pinned below the top bar (never scrolls).
- * - [HorizontalBarChart] fills the remaining height with its own independent scroll.
+ * Layout (top to bottom, nothing scrolls except the bar chart's own LazyColumn):
+ * - [CacheStatsSummaryTable] — pinned below the top bar.
+ * - [SortControl] — dropdown for choosing the bar chart's sort order.
+ * - [HorizontalBarChart] — fills remaining height, scrolls independently.
  *
- * @param entries Cache entries sorted by ISO3 code (caller responsible for ordering).
+ * @param entries Raw cache entries from the repository (unsorted).
+ * @param sortOption Currently active sort order, owned by the caller.
+ * @param onSortOptionSelected Invoked when the user picks a new sort order.
  * @param onDismiss Invoked when the user navigates back.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CacheStatsScreenContent(
     entries: List<CacheEntry>,
+    sortOption: SortOption,
+    onSortOptionSelected: (SortOption) -> Unit,
     onDismiss: () -> Unit
 ) {
     BackHandler(onBack = onDismiss)
+
+    val sortedEntries = entries.applySortOption(sortOption)
 
     CovidTheme {
         Scaffold(
@@ -138,15 +174,80 @@ fun CacheStatsScreenContent(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
+                // Sort control — fixed, not scrollable
+                SortControl(
+                    selected = sortOption,
+                    onOptionSelected = onSortOptionSelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
                 // Bar chart — fills remaining height; LazyColumn inside scrolls independently
                 HorizontalBarChart(
-                    entries = entries.map {
+                    entries = sortedEntries.map {
                         BarChartEntry(label = it.iso3Code, value = it.ageMillis.toFloat())
                     },
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 16.dp),
                     valueFormatter = { formatAge(it.toLong()) }
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sort control
+// ---------------------------------------------------------------------------
+
+/**
+ * Dropdown control that lets the user choose how the bar chart is ordered.
+ *
+ * @param selected      The currently active [SortOption].
+ * @param onOptionSelected Callback invoked when the user picks a different option.
+ * @param modifier      Applied to the [ExposedDropdownMenuBox] root.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortControl(
+    selected: SortOption,
+    onOptionSelected: (SortOption) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = selected.label,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Sort by") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            SortOption.entries.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                 )
             }
         }
@@ -225,11 +326,21 @@ private val previewEntries = listOf(
 @Preview(showBackground = true, name = "Cache Stats — with data")
 @Composable
 private fun PreviewCacheStatsWithData() {
-    CacheStatsScreenContent(entries = previewEntries, onDismiss = {})
+    CacheStatsScreenContent(
+        entries = previewEntries,
+        sortOption = SortOption.ISO_CODE_ASC,
+        onSortOptionSelected = {},
+        onDismiss = {}
+    )
 }
 
 @Preview(showBackground = true, name = "Cache Stats — empty cache")
 @Composable
 private fun PreviewCacheStatsEmpty() {
-    CacheStatsScreenContent(entries = emptyList(), onDismiss = {})
+    CacheStatsScreenContent(
+        entries = emptyList(),
+        sortOption = SortOption.ISO_CODE_ASC,
+        onSortOptionSelected = {},
+        onDismiss = {}
+    )
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -48,8 +48,8 @@ fun formatAge(millis: Long): String {
     val minutes = (totalSeconds % 3600L) / 60L
     val seconds = totalSeconds % 60L
     return when {
-        days > 0 -> "${days}d ${hours}h"
-        hours > 0 -> "${hours}h ${minutes.toString().padStart(2, '0')}m"
+        days > 0 -> "${days}d ${hours}h ${minutes.toString().padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s"
+        hours > 0 -> "${hours}h ${minutes.toString().padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s"
         minutes > 0 -> "${minutes}m ${seconds.toString().padStart(2, '0')}s"
         else -> "${seconds}s"
     }

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
@@ -1,5 +1,6 @@
 package com.rodbailey.covid.presentation.cachestats
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rodbailey.covid.data.repo.CacheEntry
@@ -7,28 +8,49 @@ import com.rodbailey.covid.data.repo.CovidRepository
 import com.rodbailey.covid.presentation.Result
 import com.rodbailey.covid.presentation.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
+private const val PREFS_FILE = "cache_stats_prefs"
+private const val PREF_SORT_OPTION = "sort_option"
+
 @HiltViewModel
 class CacheStatsViewModel @Inject constructor(
-    repo: CovidRepository
+    repo: CovidRepository,
+    @ApplicationContext context: Context
 ) : ViewModel() {
 
     data class UIState(
-        val entries: Result<List<CacheEntry>> = Result.Loading
+        val entries: Result<List<CacheEntry>> = Result.Loading,
+        val sortOption: SortOption = SortOption.ISO_CODE_ASC
     )
 
-    val uiState: StateFlow<UIState> =
-        repo.getCacheEntriesStream()
-            .asResult()
-            .map { UIState(entries = it) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(),
-                initialValue = UIState()
-            )
+    private val prefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+
+    private val _sortOption = MutableStateFlow(
+        SortOption.entries.firstOrNull { it.name == prefs.getString(PREF_SORT_OPTION, null) }
+            ?: SortOption.ISO_CODE_ASC
+    )
+
+    val uiState: StateFlow<UIState> = combine(
+        repo.getCacheEntriesStream().asResult(),
+        _sortOption
+    ) { entriesResult, sort ->
+        UIState(entries = entriesResult, sortOption = sort)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = UIState()
+    )
+
+    /** Updates the active sort option and persists it to SharedPreferences. */
+    fun setSortOption(option: SortOption) {
+        _sortOption.value = option
+        prefs.edit().putString(PREF_SORT_OPTION, option.name).apply()
+    }
 }


### PR DESCRIPTION
## Summary

Two improvements to the Cache Statistics screen:

### 1. Age labels accurate to the second
The `formatAge()` function previously coarsened labels for long durations — entries older than an hour showed `2h 05m` (dropping seconds), and entries older than a day showed `1d 03h` (dropping minutes and seconds). All tiers now always include seconds, e.g. `2h 05m 30s`, `1d 03h 22m 45s`.

Affects both the horizontal bar chart value labels and the Summary Table rows (Average age, Oldest entry, Youngest entry).

### 2. Sort control with persistence
A sort dropdown is added above the horizontal bar chart (outside the scrollable area) with four options:
- ISO Code (up) — default
- ISO Code (down)
- Age (up)
- Age (down)

Selecting a new option immediately reorders the bar chart. The chosen sort order is persisted to `SharedPreferences` via `CacheStatsViewModel`, so it survives screen navigation and app restarts.

## Files changed
- `CacheStatsScreen.kt` — `formatAge` fix, `SortOption` enum, `SortControl` composable, stateless sort threading
- `CacheStatsViewModel.kt` — `SharedPreferences`-backed sort `MutableStateFlow`, `setSortOption()`
- `CacheStatsViewModelTest.kt` — supply `ApplicationContext` to updated constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)