### PR TITLE
fix: align stateIn initialValue with stored sort option

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
@@ -32,10 +32,12 @@ class CacheStatsViewModel @Inject constructor(
 
     private val prefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
 
-    private val _sortOption = MutableStateFlow(
+    // Read once so both _sortOption and the stateIn initialValue agree on the starting sort.
+    private val initialSortOption: SortOption =
         SortOption.entries.firstOrNull { it.name == prefs.getString(PREF_SORT_OPTION, null) }
             ?: SortOption.ISO_CODE_ASC
-    )
+
+    private val _sortOption = MutableStateFlow(initialSortOption)
 
     val uiState: StateFlow<UIState> = combine(
         repo.getCacheEntriesStream().asResult(),
@@ -45,7 +47,7 @@ class CacheStatsViewModel @Inject constructor(
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
-        initialValue = UIState()
+        initialValue = UIState(sortOption = initialSortOption)
     )
 
     /** Updates the active sort option and persists it to SharedPreferences. */


### PR DESCRIPTION
## Problem

`CacheStatsViewModel` hardcoded `UIState(sortOption = ISO_CODE_ASC)` as the `stateIn` initial value, but `_sortOption` was initialised from SharedPreferences — which may hold a different value if the user had previously selected a different sort order.

When those two values disagreed, `combine`'s first emission (`Loading` + stored sort option) did not deduplicate against the `initialValue`, producing a spurious extra `Loading` item in the `uiState` stream. This caused 4 `CacheStatsViewModelTest` failures:

- `empty_cache_emits_success_with_empty_list` — got `Loading` after `skipItems(1)`
- `cache_with_entries_emits_success_with_correct_count` — got `Loading` after `skipItems(1)`
- `cache_entries_preserve_iso3_codes_and_age_values` — `ClassCastException` casting `Loading` to `Success`
- `single_cache_entry_emits_success_with_one_entry` — `ClassCastException` casting `Loading` to `Success`

## Fix

Read SharedPreferences once into `initialSortOption` and use it for both `_sortOption` and the `stateIn` `initialValue`, so they always start from the same value and `combine`'s first emission is correctly deduplicated.

## Testing

All 58 instrumented tests pass on Medium_Phone_26 (API 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)