### PR TITLE
feat: add jacocoAndroidTestReport task with UI exclusions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,29 @@ jacoco {
     toolVersion = "0.8.11"
 }
 
+val jacocoExclusions = listOf(
+    // Android/Hilt generated
+    "**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*",
+    "**/*Test*.*", "android/**/*.*",
+    "**/*_Hilt*.*", "**/Hilt_*.*", "**/*_Factory*.*", "**/*_MembersInjector*.*",
+    // Compose compiler generated
+    "**/*ComposableSingletons*.*",
+    "**/*\$\$composableLambda*.*",
+    // Compose UI — screens, components, theme, navigation
+    "**/presentation/theme/**",
+    "**/presentation/navigation/**",
+    "**/presentation/core/MainActivityKt*",
+    "**/presentation/main/MainScreenKt*",
+    "**/presentation/main/RegionDataPanelKt*",
+    "**/presentation/main/RegionDataPanelGridKt*",
+    "**/presentation/main/RegionSearchResultItemKt*",
+    "**/presentation/main/GlobalRegionIconKt*",
+    "**/presentation/main/MainScreenTag*",
+    "**/presentation/main/ReportDataParameterProvider*",
+    "**/presentation/cachestats/CacheStatsScreenKt*",
+    "**/presentation/cachestats/HorizontalBarChartKt*"
+)
+
 tasks.register<JacocoReport>("jacocoUnitTestReport") {
     dependsOn("testDebugUnitTest")
 
@@ -73,11 +96,7 @@ tasks.register<JacocoReport>("jacocoUnitTestReport") {
         xml.required.set(false)
     }
 
-    val fileFilter = listOf(
-        "**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*",
-        "**/*Test*.*", "android/**/*.*",
-        "**/*_Hilt*.*", "**/Hilt_*.*", "**/*_Factory*.*", "**/*_MembersInjector*.*"
-    )
+    val fileFilter = jacocoExclusions
     val debugTree = fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
         exclude(fileFilter)
     }
@@ -87,6 +106,28 @@ tasks.register<JacocoReport>("jacocoUnitTestReport") {
     classDirectories.setFrom(files(debugTree))
     executionData.setFrom(fileTree(layout.buildDirectory.get()) {
         include("outputs/unit_test_code_coverage/debugUnitTest/*.exec")
+    })
+}
+
+tasks.register<JacocoReport>("jacocoAndroidTestReport") {
+    dependsOn("connectedAndroidTest")
+
+    reports {
+        html.required.set(true)
+        xml.required.set(false)
+    }
+
+    val debugTree = fileTree(
+        "${layout.buildDirectory.get()}/intermediates/classes/debug/transformDebugClassesWithAsm/dirs"
+    ) {
+        exclude(jacocoExclusions)
+    }
+    val mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories.setFrom(files(mainSrc))
+    classDirectories.setFrom(files(debugTree))
+    executionData.setFrom(fileTree(layout.buildDirectory.get()) {
+        include("outputs/code_coverage/debugAndroidTest/connected/**/*.ec")
     })
 }
 


### PR DESCRIPTION
## Summary

- Adds a shared `jacocoExclusions` list in `build.gradle.kts` covering Android/Hilt generated code, Compose compiler-generated synthetic classes, and all user-written Compose UI files (screens, components, theme, navigation)
- Introduces a new `jacocoAndroidTestReport` Gradle task that reads the instrumented test `.ec` file and applies exclusions, so coverage reflects only the ViewModel, repository, domain, and data layers
- Wires the existing `jacocoUnitTestReport` task to use the same shared exclusion list

Run with: `./gradlew jacocoAndroidTestReport`
Report output: `app/build/reports/jacoco/jacocoAndroidTestReport/html/index.html`

## Coverage results (instrumented tests, UI excluded)

| Metric | Before | After |
|---|---|---|
| Instructions | 51% | 72% |
| Branches | 32% | 62% |
| Classes | 100 | 71 |

## Test plan

- [ ] Run `./gradlew jacocoAndroidTestReport` on a connected device and confirm BUILD SUCCESSFUL with no class-mismatch warnings
- [ ] Open the HTML report and confirm Compose UI files (CacheStatsScreen, HorizontalBarChart, MainScreen, etc.) are absent
- [ ] Confirm ViewModels, repositories, and domain classes are still present in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)