### PR TITLE
feat: upgrade Hilt to 2.59.2 and hilt-navigation-compose to 1.3.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,9 +171,9 @@ dependencies {
     //ksp "androidx.room:room-compiler:$room_version"
 
     // Hilt dependencies
-    implementation("com.google.dagger:hilt-android:2.58")
-    ksp("com.google.dagger:hilt-android-compiler:2.58")
-    androidTestImplementation("com.google.dagger:hilt-android-testing:2.58")
+    implementation("com.google.dagger:hilt-android:2.59.2")
+    ksp("com.google.dagger:hilt-android-compiler:2.59.2")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.59.2")
     // Explicit kotlin-metadata-jvm override allows Hilt to process Kotlin 2.3 metadata
     ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
 
@@ -192,6 +192,6 @@ dependencies {
 
     // Compose Navigation + type-safe routes
     implementation("androidx.navigation:navigation-compose:2.8.4")
-    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 }


### PR DESCRIPTION
## Summary

- Upgrades `com.google.dagger:hilt-android` from `2.58` to `2.59.2`
- Upgrades `com.google.dagger:hilt-android-compiler` from `2.58` to `2.59.2`
- Upgrades `com.google.dagger:hilt-android-testing` from `2.58` to `2.59.2`
- Upgrades `androidx.hilt:hilt-navigation-compose` from `1.2.0` to `1.3.0`

All four Hilt-related artifacts upgraded together to keep versions consistent.

## Test plan

- [x] `./gradlew test connectedAndroidTest` — all 58 instrumented tests and all unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)