### PR TITLE
feat: upgrade Room to 2.8.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,9 +161,9 @@ dependencies {
 
 //    def room_version = "2.6.1"
 
-    implementation("androidx.room:room-runtime:2.7.0")
-    ksp("androidx.room:room-compiler:2.7.0")
-    implementation("androidx.room:room-ktx:2.7.0")
+    implementation("androidx.room:room-runtime:2.8.4")
+    ksp("androidx.room:room-compiler:2.8.4")
+    implementation("androidx.room:room-ktx:2.8.4")
 
     // To use Kotlin annotation processing tool (kapt)
 //    kapt("androidx.room:room-compiler:2.6.1")


### PR DESCRIPTION
## Summary

- Upgrades `androidx.room:room-runtime` from `2.7.0` to `2.8.4`
- Upgrades `androidx.room:room-compiler` from `2.7.0` to `2.8.4`
- Upgrades `androidx.room:room-ktx` from `2.7.0` to `2.8.4`

All three Room artifacts upgraded together to keep versions consistent.

## Test plan

- [x] `./gradlew test connectedAndroidTest` — all 58 instrumented tests and all unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)