### PR TITLE
feat: upgrade navigation-compose from 2.8.4 to 2.9.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,7 +191,7 @@ dependencies {
     androidTestImplementation("app.cash.turbine:turbine:1.2.1")
 
     // Compose Navigation + type-safe routes
-    implementation("androidx.navigation:navigation-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.9.8")
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 }


### PR DESCRIPTION
## Summary

- Upgrades `androidx.navigation:navigation-compose` from `2.8.4` to `2.9.8`

## Test plan

- [x] `./gradlew test connectedAndroidTest` — all 58 instrumented tests and all unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)