### PR TITLE
feat: upgrade kotlinx-serialization-json from 1.7.3 to 1.11.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -193,5 +193,5 @@ dependencies {
     // Compose Navigation + type-safe routes
     implementation("androidx.navigation:navigation-compose:2.9.8")
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }


### PR DESCRIPTION
## Summary

- Upgrades `org.jetbrains.kotlinx:kotlinx-serialization-json` from `1.7.3` to `1.11.0`

## Test plan

- [x] `./gradlew test connectedAndroidTest` — all 58 instrumented tests and all unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)