### PR TITLE
feat: upgrade Kotlin plugins and kotlin-metadata-jvm to 2.3.21

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,7 @@ tasks.register<JacocoReport>("jacocoAndroidTestReport") {
 }
 
 configurations.all {
-    resolutionStrategy.force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
+    resolutionStrategy.force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")
 }
 
 dependencies {
@@ -175,7 +175,7 @@ dependencies {
     ksp("com.google.dagger:hilt-android-compiler:2.59.2")
     androidTestImplementation("com.google.dagger:hilt-android-testing:2.59.2")
     // Explicit kotlin-metadata-jvm override allows Hilt to process Kotlin 2.3 metadata
-    ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20")
+    ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")
 
     // Enables " = viewModel()" access to view model in compose
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
     id("com.google.devtools.ksp") version "2.3.6" apply false
     id("com.google.dagger.hilt.android") version "2.58" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.20" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21" apply false
 }


### PR DESCRIPTION
## Summary

- Upgrades `org.jetbrains.kotlin.android` from `2.3.20` to `2.3.21`
- Upgrades `org.jetbrains.kotlin.plugin.compose` from `2.3.20` to `2.3.21`
- Upgrades `org.jetbrains.kotlin.plugin.serialization` from `2.3.20` to `2.3.21`
- Upgrades `org.jetbrains.kotlin:kotlin-metadata-jvm` from `2.3.20` to `2.3.21`

All four Kotlin artifacts upgraded together to keep versions consistent.

## Test plan

- [x] `./gradlew test connectedAndroidTest` — all 58 instrumented tests and all unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)