### PR TITLE
fix: remove redundant kotlin jvmTarget block in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,11 +42,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
-        }
-    }
     buildFeatures {
         compose = true
         buildConfig = true


### PR DESCRIPTION
## Summary
- Removes the `kotlin { compilerOptions { jvmTarget.set(...) } }` block from `app/build.gradle.kts`
- AGP 9.x automatically infers `jvmTarget` from `compileOptions.targetCompatibility`, making the explicit block redundant and the cause of an IDE warning

## Test plan
- [ ] Project builds successfully with `./gradlew assembleDebug`
- [ ] Unit tests pass with `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)