### PR TITLE
fix: apply @StringRes to both param and field in UIText

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
@@ -20,7 +20,7 @@ sealed class UIText {
      * String from XML resource
      */
     data class StringResource(
-        @StringRes val resId: Int,
+        @param:StringRes @field:StringRes val resId: Int,
         val args: List<Any> = emptyList()
     ) : UIText() {
         constructor(@StringRes resId: Int, vararg args: Any) : this(resId, args.toList())
@@ -30,7 +30,7 @@ sealed class UIText {
      * String from XML resource and another [UIText]
      */
     data class CompoundStringResource(
-        @StringRes val resId: Int,
+        @param:StringRes @field:StringRes val resId: Int,
         val uiText: UIText
     ) : UIText()
 


### PR DESCRIPTION
## Summary
- Updates `@StringRes` annotations on `resId` in `StringResource` and `CompoundStringResource` to use explicit `@param:StringRes @field:StringRes` targets
- Kotlin 2.x will apply annotations on constructor `val` params to both the parameter and backing field by default; this opts in explicitly and silences the compiler warning (KT-73255)
- All 58 instrumented tests and unit tests pass with no regressions

## Test plan
- [x] `./gradlew test` passes
- [x] `./gradlew connectedAndroidTest` passes (58/58 on Pixel 3 - API 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)