### PR TITLE
fix: disable Room schema export in AppDatabase

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/AppDatabase.kt
@@ -3,7 +3,7 @@ package com.rodbailey.covid.data.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [RegionEntity::class, RegionStatsEntity::class], version = 2)
+@Database(entities = [RegionEntity::class, RegionStatsEntity::class], version = 2, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun regionDao() : RegionDao
     abstract fun regionStatsDao() : RegionStatsDao


### PR DESCRIPTION
## Summary
- Adds `exportSchema = false` to the `@Database` annotation in `AppDatabase.kt`
- Silences the KSP warning about a missing `room.schemaLocation` — no migration tests exist in this project so schema export is unnecessary

## Test plan
- [ ] `./gradlew assembleDebug` builds with no Room schema export warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)