### PR TITLE
fix: resolve four compiler warnings in test sources

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
@@ -45,7 +45,7 @@ class FakeCovidRepository() : CovidRepository {
             FakeRegions.REGIONS.keys.toList())
     }
 
-    override fun getRegionStatsStream(iso3code: RegionCode): Flow<List<RegionStats>> {
+    override fun getRegionStatsStream(code: RegionCode): Flow<List<RegionStats>> {
         if (allMethodsThrowException) {
             throw RuntimeException()
         }
@@ -54,14 +54,14 @@ class FakeCovidRepository() : CovidRepository {
             return flowOf(emptyList())
         }
 
-        val reportData = if (iso3code is GlobalCode) {
+        val reportData = if (code is GlobalCode) {
             FakeRegions.GLOBAL_REGION_STATS
         } else {
-            val region = FakeRegions.REGIONS.keys.first { it.iso3Code == iso3code.chars }
+            val region = FakeRegions.REGIONS.keys.first { it.iso3Code == code.chars }
             FakeRegions.REGIONS[region]
         }
 
-        return flowOf(listOf(reportData!!.toRegionStats(iso3code.chars)))
+        return flowOf(listOf(reportData!!.toRegionStats(code.chars)))
     }
 
     fun setAllMethodsThrowException(value: Boolean) {

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextComposableAsStringTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/core/UITextComposableAsStringTest.kt
@@ -1,6 +1,6 @@
 package com.rodbailey.covid.presentation.core
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rodbailey.covid.R
 import org.junit.Assert.assertEquals

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainViewModelTest.kt
@@ -96,6 +96,7 @@ class MainViewModelTest {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun search_text_of_brazil_matches_exactly_one_region() =
         runTest(UnconfinedTestDispatcher()) {
             // Type "Brazil" into the search box
@@ -146,15 +147,15 @@ class MainViewModelTest {
             val dataPanelLoaded = awaitItem()
             Assert.assertTrue(dataPanelLoaded.dataPanelUIState is MainViewModel.DataPanelUIState.DataPanelOpenWithData)
 
-            val data =
-                (dataPanelLoaded.dataPanelUIState as MainViewModel.DataPanelUIState.DataPanelOpenWithData).reportData
+            val openData =
+                dataPanelLoaded.dataPanelUIState as MainViewModel.DataPanelUIState.DataPanelOpenWithData
+            val data = openData.reportData
             Assert.assertEquals(FakeRegions.GLOBAL_REGION_STATS.active, data.active)
             Assert.assertEquals(FakeRegions.GLOBAL_REGION_STATS.deaths, data.deaths)
             Assert.assertEquals(FakeRegions.GLOBAL_REGION_STATS.confirmed, data.confirmed)
             Assert.assertEquals(FakeRegions.GLOBAL_REGION_STATS.recovered, data.recovered)
 
-            val title =
-                (dataPanelLoaded.dataPanelUIState as MainViewModel.DataPanelUIState.DataPanelOpenWithData).reportDataTitle
+            val title = openData.reportDataTitle
             Assert.assertEquals(FakeRegions.GLOBAL_REGION.name, title.asString(context))
         }
     }


### PR DESCRIPTION
## Summary
- `FakeCovidRepository`: rename parameter `iso3code` → `code` to match supertype `CovidRepository`
- `UITextComposableAsStringTest`: migrate `createComposeRule` to v2 API
- `MainUITest`: migrate `createAndroidComposeRule` to v2 API
- `MainViewModelTest`: add missing `@OptIn(ExperimentalCoroutinesApi::class)` and extract redundant cast to a named variable

## Test plan
- [x] `./gradlew connectedAndroidTest` — 58/58 passed, 0 failed on Pixel 3 API 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)