### PR TITLE
fix: migrate to edge-to-edge and remove deprecated statusBarColor

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
@@ -3,6 +3,7 @@ package com.rodbailey.covid.presentation.core
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -16,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             val navController = rememberNavController()
             NavHost(navController = navController, startDestination = MainRoute) {

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -4,10 +4,13 @@ import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.LinearProgressIndicator
@@ -149,6 +152,7 @@ fun MainScreenContent(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .then(tripleTapModifier)
             ) {
                 // Search text field with global icon at right

--- a/app/src/main/java/com/rodbailey/covid/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.rodbailey.covid.presentation.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,11 +8,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -53,15 +48,6 @@ fun CovidTheme(
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
-
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,


### PR DESCRIPTION
## Summary
- Calls `enableEdgeToEdge()` in `MainActivity` before `setContent`
- Removes the `SideEffect` block from `CovidTheme` that set the deprecated `window.statusBarColor` (deprecated in API 35)
- Adds `Modifier.windowInsetsPadding(WindowInsets.safeDrawing)` to the `Column` in `MainScreenContent` to prevent the search field being occluded by the status bar and the region list being occluded by the navigation bar

## Test plan
- [x] App launches correctly with transparent status bar and content drawing behind it
- [x] Search field is fully visible below the status bar
- [x] Region list scrolls above the navigation bar with no clipping
- [x] Cache Statistics screen renders correctly (uses `Scaffold` which handles insets automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)