### PR TITLE
fix: bump Java source/target compatibility from 8 to 11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
## Summary
- Bumps `compileOptions` `sourceCompatibility` and `targetCompatibility` from `VERSION_1_8` to `VERSION_11` in `app/build.gradle.kts`
- Silences the Java compiler warning from JDK 17+ that `--source 8 / --target 8` is obsolete and will be removed in a future release
- `VERSION_11` is the lowest non-deprecated value; desugaring handles compatibility with devices below API 26

## Test plan
- [ ] `./gradlew assembleDebug` builds with no Java source/target version deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)