### PR TITLE
fix: bump targetSdk to 36 and remove dead comments from build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,11 +14,10 @@ android {
     defaultConfig {
         applicationId = "com.rodbailey.covid"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 
-//        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"?
         testInstrumentationRunner = "com.rodbailey.covid.core.di.CustomTestRunner"
         vectorDrawables {
             useSupportLibrary = true
@@ -153,16 +152,9 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:3.0.0")
     implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
 
-//    def room_version = "2.6.1"
-
     implementation("androidx.room:room-runtime:2.8.4")
     ksp("androidx.room:room-compiler:2.8.4")
     implementation("androidx.room:room-ktx:2.8.4")
-
-    // To use Kotlin annotation processing tool (kapt)
-//    kapt("androidx.room:room-compiler:2.6.1")
-    // To use Kotlin Symbol Processing (KSP)
-    //ksp "androidx.room:room-compiler:$room_version"
 
     // Hilt dependencies
     implementation("com.google.dagger:hilt-android:2.59.2")


### PR DESCRIPTION
## Summary
- Bumps `targetSdk` from 34 to 36 to align with `compileSdk`, opting into Android 15 behaviour changes and avoiding Play Store warnings
- Removes four commented-out dead lines: old `AndroidJUnitRunner` reference, `room_version` variable, and superseded `kapt`/`ksp` Room compiler lines

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)