### PR TITLE
refactor: remove configurations.all kotlin-metadata-jvm workaround

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,10 +124,6 @@ tasks.register<JacocoReport>("jacocoAndroidTestReport") {
     })
 }
 
-configurations.all {
-    resolutionStrategy.force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")
-}
-
 dependencies {
 
     implementation("androidx.core:core-ktx:1.18.0")


### PR DESCRIPTION
## Summary
- Removes the `configurations.all { resolutionStrategy.force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21") }` block from `app/build.gradle.kts`
- Hilt 2.59.2 with Kotlin 2.3.21 no longer requires forcing this transitive dependency — the explicit `ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")` in the dependencies block is sufficient
- Verified by building successfully without the block

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)