### PR TITLE
refactor: remove explicit ksp kotlin-metadata-jvm dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,9 +156,6 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.59.2")
     ksp("com.google.dagger:hilt-android-compiler:2.59.2")
     androidTestImplementation("com.google.dagger:hilt-android-testing:2.59.2")
-    // Explicit kotlin-metadata-jvm override allows Hilt to process Kotlin 2.3 metadata
-    ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")
-
     // Enables " = viewModel()" access to view model in compose
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")


### PR DESCRIPTION
## Summary
- Removes `ksp("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.21")` from `app/build.gradle.kts`
- Hilt 2.59.2 pulls in a compatible version of `kotlin-metadata-jvm` automatically — the explicit override is no longer needed
- Verified by building successfully without it

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)