### PR TITLE
refactor: replace Surface+Column with Scaffold in MainScreenContent

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -4,18 +4,15 @@ import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -144,16 +141,15 @@ fun MainScreenContent(
     }
 
     CovidTheme {
-        // A surface container using the 'background' color from the theme
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background
-        ) {
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .then(tripleTapModifier)
+        ) { innerPadding ->
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
-                    .then(tripleTapModifier)
+                    .padding(innerPadding)
             ) {
                 // Search text field with global icon at right
                 TextField(


### PR DESCRIPTION
## Summary
- Replaces `Surface` + `Column` with `Scaffold` in `MainScreenContent`
- Makes `MainScreen` consistent with `CacheStatsScreen` which already uses `Scaffold`
- Removes the manual `windowInsetsPadding(WindowInsets.safeDrawing)` — `Scaffold`'s `innerPadding` handles insets automatically
- Removes unused imports: `Surface`, `WindowInsets`, `safeDrawing`, `windowInsetsPadding`

## Test plan
- [x] Verified on device — search field correctly below status bar, list ends above navigation bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)