### PR TITLE
fix: catch Exception instead of Throwable in loadReportDataForRegion

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -182,7 +182,7 @@ class MainViewModel @Inject constructor(
                     dataPanelUIState.value =
                         DataPanelOpenWithData(regionName, regionStatsList.first().toReportData())
                 }
-            } catch (th: Throwable) {
+            } catch (th: Exception) {
                 Timber.e(th, "Exception while getting report data for region \"$regionName\"")
                 showErrorMessage(
                     UIText.CompoundStringResource(


### PR DESCRIPTION
## Summary
- Changes `catch (th: Throwable)` to `catch (th: Exception)` in `loadReportDataForRegion`
- `CancellationException` extends `Throwable` (not `Exception`), so the previous code caught it when `loadReportJob?.cancel()` was called — triggering a spurious "failed to load" error toast and setting `dataPanelUIState = DataPanelClosed`, which raced with the new job's `DataPanelOpenWithLoading` write when the user tapped a second region while the first was still loading

## Test plan
- [ ] Tap a region, then quickly tap a second region — no error toast should appear and the data panel should show the second region's data

🤖 Generated with [Claude Code](https://claude.com/claude-code)