### PR TITLE
fix: re-throw CancellationException in loadReportDataForRegion

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -182,6 +183,8 @@ class MainViewModel @Inject constructor(
                     dataPanelUIState.value =
                         DataPanelOpenWithData(regionName, regionStatsList.first().toReportData())
                 }
+            } catch (th: CancellationException) {
+                throw th
             } catch (th: Exception) {
                 Timber.e(th, "Exception while getting report data for region \"$regionName\"")
                 showErrorMessage(


### PR DESCRIPTION
## Summary

- `CancellationException` extends `Exception`, so the existing `catch (th: Exception)` block was catching job cancellations as well as real errors
- When the user tapped a second region before the first request finished, the old job's cancellation triggered the error toast and set `dataPanelUIState = DataPanelClosed`, racing with the new job's `DataPanelOpenWithLoading` write
- Fix adds a preceding `catch (th: CancellationException) { throw th }` clause so cancellation propagates cleanly without running error-handling side effects

## Test plan

- [ ] Tap a region to load stats, then quickly tap a different region — confirm no spurious error toast appears and the loading indicator stays visible
- [ ] Tap a region and let it load fully — confirm stats still display correctly
- [ ] Confirm existing instrumented tests pass: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)