### PR TITLE
fix: cancel loadReportJob when data panel is collapsed

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -156,6 +156,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun collapseDataPanel() {
+        loadReportJob?.cancel()
         dataPanelUIState.value = DataPanelClosed
     }
 


### PR DESCRIPTION
## Summary

- `collapseDataPanel()` previously only set `dataPanelUIState = DataPanelClosed` without cancelling the in-flight `loadReportJob`
- A slow stats fetch (e.g. 2s network call) completing after the user dismissed the panel would write `DataPanelOpenWithData`, silently reopening it
- Fix adds `loadReportJob?.cancel()` before the state write, consistent with how `loadReportDataForRegion` already cancels any previous job before starting a new one

## Test plan

- [ ] Tap a region to start loading, then immediately tap the data panel to collapse it — confirm the panel stays closed and no data appears
- [ ] Tap a region and let it load fully — confirm stats still display correctly
- [ ] Run instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)