### PR TITLE
fix: catch Error in loadReportDataForRegion to prevent frozen loading panel

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -195,6 +195,11 @@ class MainViewModel @Inject constructor(
                     )
                 )
                 dataPanelUIState.value = DataPanelClosed
+            } catch (th: Error) {
+                // No toast is shown because rendering a Toast during OOM/StackOverflow is unreliable.
+                // Close the panel so the UI isn't frozen, then re-throw so crash reporters see it.
+                dataPanelUIState.value = DataPanelClosed
+                throw th
             }
         }
     }


### PR DESCRIPTION
## Summary

- After the `catch(Throwable)` → `catch(Exception)` change in PR #74, JVM `Error` subclasses (OOM, StackOverflow, etc.) thrown inside `repo.getRegionStatsStream(...).first()` escaped the catch block entirely
- This left `dataPanelUIState` stuck on `DataPanelOpenWithLoading` with no user feedback, and no chance for crash reporters to log the error
- Fix adds a `catch(th: Error)` clause that closes the panel then re-throws, so the UI recovers and crash reporters still see the full error
- No toast is shown for `Error`s — rendering a Toast during OOM/StackOverflow is unreliable

## Test plan

- [ ] Tap a region and let stats load normally — confirm panel shows data correctly
- [ ] Run instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)