### PR TITLE
fix: make showErrorMessage a suspend fun to avoid unnecessary coroutine launch

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -154,10 +154,8 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun showErrorMessage(message: UIText) {
-        viewModelScope.launch {
-            errorChannel.send(message)
-        }
+    private suspend fun showErrorMessage(message: UIText) {
+        errorChannel.send(message)
     }
 
     private fun collapseDataPanel() {


### PR DESCRIPTION
## Summary

- `showErrorMessage` was wrapping a `Channel.BUFFERED` send in `viewModelScope.launch`, adding an unnecessary dispatch cycle and a narrow window where the message could be silently dropped if `viewModelScope` was cancelled before the launched coroutine ran
- `Channel.BUFFERED` (capacity 64) means `send` completes without suspending when buffer has space — no coroutine wrapper needed
- Both call sites (`init` block and `loadReportDataForRegion`) are already inside coroutines, so making the function `suspend` drops in cleanly

## Test plan

- [ ] Trigger a network error and confirm the error toast still appears
- [ ] Run instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)