### PR TITLE
refactor: replace init block with declarative regionLoadError flow merged into errorFlow

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -23,12 +23,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -80,15 +81,19 @@ class MainViewModel @Inject constructor(
         data class OnSearchTextChanged(val text: String) : MainIntent
     }
 
-    // Error text from network failures etc. Use a Channel to prevent event duplication on
-    // configuration change. BUFFERED capacity avoids a race where an error is emitted before
-    // the UI has subscribed to errorFlow — with the default RENDEZVOUS (capacity = 0) the send
-    // would suspend until there is a receiver, and the message could be lost if the sending
-    // coroutine is cancelled before a collector starts.
     private val errorChannel = Channel<UIText>(Channel.BUFFERED)
-    val errorFlow = errorChannel.receiveAsFlow()
 
     private val regions: Flow<Result<List<Region>>> = repo.getRegionsStream().asResult()
+
+    // Emits the error message once if the regions stream fails; merged into errorFlow below.
+    private val regionLoadError: Flow<UIText> = regions
+        .filterIsInstance<Result.Error>()
+        .take(1)
+        .map { UIText.StringResource(R.string.failed_to_load_country_list) }
+
+    // Stats errors are sent via errorChannel; region load errors come through regionLoadError.
+    val errorFlow: Flow<UIText> = merge(regionLoadError, errorChannel.receiveAsFlow())
+
     private val searchText = MutableStateFlow("")
     private val dataPanelUIState = MutableStateFlow<DataPanelUIState>(DataPanelClosed)
 
@@ -100,16 +105,6 @@ class MainViewModel @Inject constructor(
     // Filtered region list recomputed only when regions or search text change
     private val filteredRegions = combine(sortedRegions, searchText) { aRegions, aSearchText ->
         Pair(matchingRegionsResult(aRegions, aSearchText), aSearchText)
-    }
-
-    init {
-        // Show the error message exactly once when the regions flow fails, not on every
-        // combine re-emission (e.g. each keystroke) that would otherwise repeat the toast.
-        viewModelScope.launch {
-            if (regions.filter { it is Result.Error }.firstOrNull() != null) {
-                showErrorMessage(UIText.StringResource(R.string.failed_to_load_country_list))
-            }
-        }
     }
 
     // Communicates UI state changes to the view


### PR DESCRIPTION
## Summary

- Removes the imperative `init` block that launched a coroutine to watch `regions` for `Result.Error` and call `showErrorMessage`
- Adds `regionLoadError: Flow<UIText>` — a cold flow derived from `regions` that emits the error message once (via `filterIsInstance + take(1)`) if the regions stream fails
- Changes `errorFlow` from `errorChannel.receiveAsFlow()` to `merge(regionLoadError, errorChannel.receiveAsFlow())`, so both region load errors and stats load errors are surfaced through the same public API

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] All unit tests pass (`./gradlew test`)
- [ ] `exception_from_api_when_loading_country_list_results_in_error_message` confirms region load errors still reach `errorFlow`
- [ ] `exception_from_api_when_loading_country_stats_results_in_error_message` confirms stats errors still reach `errorFlow` via `errorChannel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)