### PR TITLE
fix: replace isEmpty/first() pair with firstOrNull() for region stats

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -169,8 +169,8 @@ class MainViewModel @Inject constructor(
         loadReportJob = viewModelScope.launch {
             try {
                 dataPanelUIState.value = DataPanelUIState.DataPanelOpenWithLoading
-                val regionStatsList = repo.getRegionStatsStream(regionIso3Code).first()
-                if (regionStatsList.isEmpty()) {
+                val regionStats = repo.getRegionStatsStream(regionIso3Code).first().firstOrNull()
+                if (regionStats == null) {
                     showErrorMessage(
                         UIText.CompoundStringResource(
                             R.string.no_data_available_for,
@@ -180,7 +180,7 @@ class MainViewModel @Inject constructor(
                     dataPanelUIState.value = DataPanelClosed
                 } else {
                     dataPanelUIState.value =
-                        DataPanelOpenWithData(regionName, regionStatsList.first().toReportData())
+                        DataPanelOpenWithData(regionName, regionStats.toReportData())
                 }
             } catch (th: CancellationException) {
                 throw th


### PR DESCRIPTION
## Summary

- Replaces the two-step `regionStatsList.isEmpty()` + `regionStatsList.first()` pattern with a single `firstOrNull()` call
- Eliminates the confusing proximity of `Flow.first()` (line 172) and `List.first()` (line 183) on adjacent lines — readers no longer need to reason about which `first()` could throw
- The null check (`== null`) directly expresses the empty-list case without a redundant guard

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] `empty_country_stats_closes_data_panel_and_shows_error` confirms the null/empty path still shows the correct error message
- [ ] `load_report_for_global_gives_global_data_in_data_panel` confirms the success path still populates the data panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)