### PR TITLE
fix: revert region load error detection to init block approach

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -23,13 +23,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -81,18 +80,23 @@ class MainViewModel @Inject constructor(
         data class OnSearchTextChanged(val text: String) : MainIntent
     }
 
+    // BUFFERED capacity avoids a race where an error is emitted before the UI has subscribed to
+    // errorFlow — with RENDEZVOUS (capacity = 0) the send would suspend and the message could be
+    // lost if the sending coroutine is cancelled before a collector starts.
     private val errorChannel = Channel<UIText>(Channel.BUFFERED)
+    val errorFlow = errorChannel.receiveAsFlow()
 
     private val regions: Flow<Result<List<Region>>> = repo.getRegionsStream().asResult()
 
-    // Emits the error message once if the regions stream fails; merged into errorFlow below.
-    private val regionLoadError: Flow<UIText> = regions
-        .filterIsInstance<Result.Error>()
-        .take(1)
-        .map { UIText.StringResource(R.string.failed_to_load_country_list) }
-
-    // Stats errors are sent via errorChannel; region load errors come through regionLoadError.
-    val errorFlow: Flow<UIText> = merge(regionLoadError, errorChannel.receiveAsFlow())
+    init {
+        // Show the error message exactly once per ViewModel lifetime when the regions flow fails,
+        // not on every repeatOnLifecycle STARTED cycle that would otherwise repeat the toast.
+        viewModelScope.launch {
+            if (regions.filter { it is Result.Error }.firstOrNull() != null) {
+                showErrorMessage(UIText.StringResource(R.string.failed_to_load_country_list))
+            }
+        }
+    }
 
     private val searchText = MutableStateFlow("")
     private val dataPanelUIState = MutableStateFlow<DataPanelUIState>(DataPanelClosed)


### PR DESCRIPTION
## Summary

Reverts the `regionLoadError`/`merge` pattern introduced in PR #79 back to an eager `init` block.

- The `merge` approach kept `regionLoadError` as a cold `Flow`, which meant it re-subscribed to `regions` on every `repeatOnLifecycle(STARTED)` cycle. On rotation or app resume with a broken network, the region load error toast would fire again.
- The `init` block sends to `errorChannel` exactly once per ViewModel lifetime, regardless of how many times the UI re-subscribes to `errorFlow`.

This is a deliberate reversion to a previous approach in the interests of correctness and clarity, without functional loss. Both approaches share the same known trade-off (a second cold subscription to `regions` alongside `sortedRegions`), and both buffer the error in `errorChannel` so it is not lost if the UI subscribes late.

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] `exception_from_api_when_loading_country_list_results_in_error_message` confirms the error is still delivered correctly
- [ ] Manual test: force a region load failure, rotate the device — confirm the toast appears only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)