### PR TITLE
perf: stabilise ViewModel callbacks in MainScreen with remember(viewModel)

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -79,16 +79,32 @@ fun MainScreen(onNavigateToCacheStats: () -> Unit = {}) {
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    MainScreenContent(
-        uiState = uiState,
-        onSearchTextChanged = { viewModel.processIntent(OnSearchTextChanged(it)) },
-        onGlobalClicked = { viewModel.processIntent(LoadReportDataForGlobal) },
-        onRegionClicked = { region ->
+    // Stable lambda references — captured only once per ViewModel lifetime so that
+    // remember(region, onRegionClicked) inside the LazyColumn retains its per-item
+    // callback across recompositions instead of always missing due to a new reference.
+    val onSearchTextChanged: (String) -> Unit = remember(viewModel) {
+        { viewModel.processIntent(OnSearchTextChanged(it)) }
+    }
+    val onGlobalClicked: () -> Unit = remember(viewModel) {
+        { viewModel.processIntent(LoadReportDataForGlobal) }
+    }
+    val onRegionClicked: (Region) -> Unit = remember(viewModel) {
+        { region ->
             viewModel.processIntent(
                 LoadReportDataForRegion(UIText.DynamicString(region.name), region.toRegionCode())
             )
-        },
-        onDataPanelCollapsed = { viewModel.processIntent(MainViewModel.MainIntent.CollapseDataPanel) },
+        }
+    }
+    val onDataPanelCollapsed: () -> Unit = remember(viewModel) {
+        { viewModel.processIntent(MainViewModel.MainIntent.CollapseDataPanel) }
+    }
+
+    MainScreenContent(
+        uiState = uiState,
+        onSearchTextChanged = onSearchTextChanged,
+        onGlobalClicked = onGlobalClicked,
+        onRegionClicked = onRegionClicked,
+        onDataPanelCollapsed = onDataPanelCollapsed,
         onTripleTap = onNavigateToCacheStats
     )
 }


### PR DESCRIPTION
## Summary

- Plain `(Region) -> Unit` lambda literals passed to `MainScreenContent` were allocated as new objects on every recomposition of `MainScreen` (which fires on every search keystroke)
- The Compose compiler only memoises `@Composable`-typed lambdas — plain function types always produce a new reference per recomposition
- This caused `remember(region, onRegionClicked)` inside the `LazyColumn` to always miss, defeating the per-item callback memoisation for every visible row on every keystroke
- Fix: wrap each ViewModel callback in `remember(viewModel)` so the lambda is evaluated once per ViewModel lifetime and produces a stable reference

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual: type in the search field and confirm the region list filters correctly
- [ ] Manual: tap a region and confirm the data panel opens with the correct stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)