### PR TITLE
fix: hide alpha(0f) elements from accessibility tree in RegionDataPanel

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -59,12 +61,15 @@ fun RegionDataPanel(
                 modifier = Modifier
                     .width(64.dp)
                     .alpha(if (isLoading) 1f else 0f)
+                    .then(if (!isLoading) Modifier.semantics { hideFromAccessibility() } else Modifier)
                     .align(Alignment.Center),
                 color = MaterialTheme.colorScheme.secondary,
                 trackColor = MaterialTheme.colorScheme.surfaceVariant
             )
             Column(
-                modifier = Modifier.alpha(if (isLoading) 0f else 1f)
+                modifier = Modifier
+                    .alpha(if (isLoading) 0f else 1f)
+                    .then(if (isLoading) Modifier.semantics { hideFromAccessibility() } else Modifier)
             ) {
                 // Region name is title of the data panel
                 Text(


### PR DESCRIPTION
## Summary

- `CircularProgressIndicator` and the data `Column` in `RegionDataPanel` were toggled using `alpha(0f)`, which only affects visual rendering — both elements remained in the semantic tree and were traversable by TalkBack
- While loading, TalkBack could announce the invisible Column's empty/zero placeholder values; while data was shown, TalkBack could reach the invisible spinner
- Fix: add `Modifier.semantics { hideFromAccessibility() }` alongside each `alpha(0f)` to explicitly remove the hidden element from the accessibility tree
- Both elements are kept in the layout (not removed from composition) to preserve the stable card height during the loading→loaded transition

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual with TalkBack enabled: tap a region, confirm TalkBack announces only the spinner while loading and only the stats content when loaded — not both

🤖 Generated with [Claude Code](https://claude.com/claude-code)