### PR TITLE
fix: hide LinearProgressIndicator from accessibility tree when not loading

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.rodbailey.covid.R
@@ -187,6 +189,7 @@ fun MainScreenContent(
                         .fillMaxWidth()
                         .height(16.dp)
                         .alpha(if (uiState.matchingRegions is Loading) 1f else 0f)
+                        .then(if (uiState.matchingRegions !is Loading) Modifier.semantics { hideFromAccessibility() } else Modifier)
                         .padding(bottom = 12.dp),
                     color = MaterialTheme.colorScheme.secondary,
                     trackColor = MaterialTheme.colorScheme.surfaceVariant


### PR DESCRIPTION
## Summary

- `LinearProgressIndicator` was hidden with `alpha(0f)` when regions were not loading, but `alpha` does not remove elements from the semantic tree
- TalkBack could still focus and announce the invisible progress indicator when no loading was occurring, confusing screen-reader users
- Fix: add `Modifier.semantics { hideFromAccessibility() }` alongside the `alpha(0f)` to remove it from the accessibility tree when not in use
- The element stays in the layout (preserving the 16dp space) — only its semantic visibility changes

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual with TalkBack enabled: confirm the progress bar is not announced when the region list is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)