### PR TITLE
perf: guard CacheStatsScreen computations with remember to avoid redundant work

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -141,7 +141,10 @@ fun CacheStatsScreenContent(
 ) {
     BackHandler(onBack = onDismiss)
 
-    val sortedEntries = entries.applySortOption(sortOption)
+    val sortedEntries = remember(entries, sortOption) { entries.applySortOption(sortOption) }
+    val barChartEntries = remember(sortedEntries) {
+        sortedEntries.map { BarChartEntry(label = it.iso3Code, value = it.ageMillis.toFloat()) }
+    }
 
     CovidTheme {
         Scaffold(
@@ -187,9 +190,7 @@ fun CacheStatsScreenContent(
 
                 // Bar chart — fills remaining height; LazyColumn inside scrolls independently
                 HorizontalBarChart(
-                    entries = sortedEntries.map {
-                        BarChartEntry(label = it.iso3Code, value = it.ageMillis.toFloat())
-                    },
+                    entries = barChartEntries,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 16.dp),
@@ -263,11 +264,11 @@ fun CacheStatsSummaryTable(
     entries: List<CacheEntry>,
     modifier: Modifier = Modifier
 ) {
-    val count = entries.size
-    val totalBytes = count * BYTES_PER_STATS_ROW
-    val avgAgeMillis = if (entries.isEmpty()) 0L else entries.map { it.ageMillis }.average().toLong()
-    val oldest = entries.maxByOrNull { it.ageMillis }
-    val youngest = entries.minByOrNull { it.ageMillis }
+    val count = remember(entries) { entries.size }
+    val totalBytes = remember(entries) { count * BYTES_PER_STATS_ROW }
+    val avgAgeMillis = remember(entries) { if (entries.isEmpty()) 0L else entries.sumOf { it.ageMillis } / count }
+    val oldest = remember(entries) { entries.maxByOrNull { it.ageMillis } }
+    val youngest = remember(entries) { entries.minByOrNull { it.ageMillis } }
 
     Card(
         modifier = modifier,


### PR DESCRIPTION
## Summary

Three sites in `CacheStatsScreen` were recomputing on every recomposition even when their inputs hadn't changed. Opening/closing the sort dropdown is enough to trigger a full recompose of `CacheStatsScreenContent`, needlessly re-running:

- An O(n log n) sort of all cache entries
- A `List<BarChartEntry>` allocation (new reference on every recompose, preventing `HorizontalBarChart` from skipping recomposition)
- Five separate list traversals for the summary statistics (including an intermediate `map { it.ageMillis }` allocation for the average)

**Fixes:**
- `remember(entries, sortOption)` — sort runs once per data/sort change
- `remember(sortedEntries)` — `BarChartEntry` list allocated once per sort change
- `remember(entries)` ×5 — summary stats computed once per data change; `entries.map{}.average()` replaced with `entries.sumOf{}` to eliminate the intermediate list allocation

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual: open the sort dropdown and confirm the bar chart and summary table do not flicker or reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)