### PR TITLE
fix: improve accessibility of RegionSearchResultItem

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
@@ -11,11 +11,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.rodbailey.covid.R
 import com.rodbailey.covid.domain.Region
 
 /**
@@ -30,14 +30,16 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .height(48.dp)
+            .semantics(mergeDescendants = true) {}
             .clickable(
+                role = Role.Button,
                 onClick = clickCallback
             )
     ) {
         Icon(
             modifier = Modifier.padding(start = 16.dp, end = 8.dp),
             imageVector = Icons.Default.AccountBox,
-            contentDescription = stringResource(R.string.region_icon_content_description)
+            contentDescription = null   // decorative; region name from Text labels the row
         )
         Text(
             fontSize = 16.sp,
@@ -47,7 +49,7 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
     }
 }
 
-@Preview()
+@Preview
 @Composable
 fun RegionSearchResultItemPreview() {
     RegionSearchResultItem(


### PR DESCRIPTION
## Summary

TalkBack announced each region list row as two separate focusable elements — first the Icon (with a generic label from strings.xml), then the region name Text — with no indication the row was interactive.

Three changes fix this:
- **`semantics(mergeDescendants = true)`** on the Row — merges Icon and Text into a single focusable node so TalkBack reads the region name as the row's combined accessible label
- **`role = Role.Button`** on `clickable` — TalkBack now appends "button" and "double tap to activate" to the announcement, making the row's interactivity clear
- **`contentDescription = null`** on the Icon — the icon is purely decorative within a labelled clickable row; its description was causing a redundant and meaningless announcement before the region name

Also removes empty `@Preview()` parentheses flagged by the IDE.

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual with TalkBack enabled: swipe through the region list and confirm each row is announced as a single element with the region name followed by "button"

🤖 Generated with [Claude Code](https://claude.com/claude-code)