### PR TITLE
refactor: move CovidTheme to MainActivity so it wraps the entire NavHost

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rodbailey.covid.data.repo.BYTES_PER_STATS_ROW
 import com.rodbailey.covid.data.repo.CacheEntry
 import com.rodbailey.covid.presentation.Result
-import com.rodbailey.covid.presentation.theme.CovidTheme
 
 // ---------------------------------------------------------------------------
 // Age formatting
@@ -146,57 +145,55 @@ fun CacheStatsScreenContent(
         sortedEntries.map { BarChartEntry(label = it.iso3Code, value = it.ageMillis.toFloat()) }
     }
 
-    CovidTheme {
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    title = { Text("Cache Statistics") },
-                    navigationIcon = {
-                        IconButton(onClick = onDismiss) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Back"
-                            )
-                        }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Cache Statistics") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
                     }
-                )
-            }
-        ) { innerPadding ->
-            Column(
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            // Summary table — fixed, not scrollable
+            CacheStatsSummaryTable(
+                entries = entries,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Sort control — fixed, not scrollable
+            SortControl(
+                selected = sortOption,
+                onOptionSelected = onSortOptionSelected,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Bar chart — fills remaining height; LazyColumn inside scrolls independently
+            HorizontalBarChart(
+                entries = barChartEntries,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                // Summary table — fixed, not scrollable
-                CacheStatsSummaryTable(
-                    entries = entries,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Sort control — fixed, not scrollable
-                SortControl(
-                    selected = sortOption,
-                    onOptionSelected = onSortOptionSelected,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Bar chart — fills remaining height; LazyColumn inside scrolls independently
-                HorizontalBarChart(
-                    entries = barChartEntries,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp),
-                    valueFormatter = { formatAge(it.toLong()) }
-                )
-            }
+                    .padding(horizontal = 16.dp),
+                valueFormatter = { formatAge(it.toLong()) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/MainActivity.kt
@@ -11,6 +11,7 @@ import com.rodbailey.covid.presentation.cachestats.CacheStatsScreen
 import com.rodbailey.covid.presentation.main.MainScreen
 import com.rodbailey.covid.presentation.navigation.CacheStatsRoute
 import com.rodbailey.covid.presentation.navigation.MainRoute
+import com.rodbailey.covid.presentation.theme.CovidTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,17 +20,19 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            val navController = rememberNavController()
-            NavHost(navController = navController, startDestination = MainRoute) {
-                composable<MainRoute> {
-                    MainScreen(
-                        onNavigateToCacheStats = { navController.navigate(CacheStatsRoute) }
-                    )
-                }
-                composable<CacheStatsRoute> {
-                    CacheStatsScreen(
-                        onDismiss = { navController.popBackStack() }
-                    )
+            CovidTheme {
+                val navController = rememberNavController()
+                NavHost(navController = navController, startDestination = MainRoute) {
+                    composable<MainRoute> {
+                        MainScreen(
+                            onNavigateToCacheStats = { navController.navigate(CacheStatsRoute) }
+                        )
+                    }
+                    composable<CacheStatsRoute> {
+                        CacheStatsScreen(
+                            onDismiss = { navController.popBackStack() }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -53,7 +53,6 @@ import com.rodbailey.covid.presentation.Result.*
 import com.rodbailey.covid.presentation.core.UIText
 import androidx.compose.ui.tooling.preview.Preview
 import com.rodbailey.covid.presentation.MainViewModel.DataPanelUIState.DataPanelClosed
-import com.rodbailey.covid.presentation.theme.CovidTheme
 
 /**
  * Main (only) screen of the covid application. Stateful entry point — owns the ViewModel,
@@ -158,17 +157,16 @@ fun MainScreenContent(
         }
     }
 
-    CovidTheme {
-        Scaffold(
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .then(tripleTapModifier)
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .then(tripleTapModifier)
-        ) { innerPadding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
+                .padding(innerPadding)
+        ) {
                 // Search text field with global icon at right
                 TextField(
                     value = uiState.searchText,
@@ -235,7 +233,6 @@ fun MainScreenContent(
                 }
             }
         }
-    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CovidTheme` was applied independently inside `MainScreenContent` and `CacheStatsScreenContent`. This had two problems:

- Any theme-level override applied above the `NavHost` (e.g. dark mode toggle, dynamic colour, white-label branding) would be silently shadowed by the inner wrappers — the inner `CovidTheme` always wins
- A future screen added to the `NavHost` without its own `CovidTheme` wrapper would render unstyled with no compiler error

`CovidTheme` is now applied once in `MainActivity.setContent`, wrapping the entire `NavHost`. All screens inherit the theme from one place, and the per-screen wrappers and their imports are removed.

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual: both MainScreen and CacheStatsScreen render with correct colours and typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)