### PR TITLE
fix: move all CacheStatsScreen strings to resources for localisation

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -30,11 +30,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.rodbailey.covid.R
 import com.rodbailey.covid.data.repo.BYTES_PER_STATS_ROW
 import com.rodbailey.covid.data.repo.CacheEntry
 import com.rodbailey.covid.presentation.Result
@@ -72,11 +74,21 @@ private fun formatBytes(bytes: Int): String = when {
 // ---------------------------------------------------------------------------
 
 /** The four orderings available to the user via the sort control. */
-enum class SortOption(val label: String) {
-    ISO_CODE_ASC("ISO Code (up)"),
-    ISO_CODE_DESC("ISO Code (down)"),
-    AGE_ASC("Age (up)"),
-    AGE_DESC("Age (down)")
+enum class SortOption {
+    ISO_CODE_ASC {
+        @Composable override fun label() = stringResource(R.string.sort_option_iso_code_asc)
+    },
+    ISO_CODE_DESC {
+        @Composable override fun label() = stringResource(R.string.sort_option_iso_code_desc)
+    },
+    AGE_ASC {
+        @Composable override fun label() = stringResource(R.string.sort_option_age_asc)
+    },
+    AGE_DESC {
+        @Composable override fun label() = stringResource(R.string.sort_option_age_desc)
+    };
+
+    @Composable abstract fun label(): String
 }
 
 private fun List<CacheEntry>.applySortOption(option: SortOption): List<CacheEntry> = when (option) {
@@ -148,12 +160,12 @@ fun CacheStatsScreenContent(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Cache Statistics") },
+                title = { Text(stringResource(R.string.cache_stats_title)) },
                 navigationIcon = {
                     IconButton(onClick = onDismiss) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                            contentDescription = stringResource(R.string.cache_stats_back_button)
                         )
                     }
                 }
@@ -224,10 +236,10 @@ private fun SortControl(
         modifier = modifier
     ) {
         OutlinedTextField(
-            value = selected.label,
+            value = selected.label(),
             onValueChange = {},
             readOnly = true,
-            label = { Text("Sort by") },
+            label = { Text(stringResource(R.string.cache_stats_sort_control_label)) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
             modifier = Modifier
@@ -240,7 +252,7 @@ private fun SortControl(
         ) {
             SortOption.entries.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(option.label) },
+                    text = { Text(option.label()) },
                     onClick = {
                         onOptionSelected(option)
                         expanded = false
@@ -272,15 +284,15 @@ fun CacheStatsSummaryTable(
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
-            SummaryRow(label = "Entries", value = count.toString())
-            SummaryRow(label = "Total size", value = formatBytes(totalBytes))
-            SummaryRow(label = "Average age", value = formatAge(avgAgeMillis))
+            SummaryRow(label = stringResource(R.string.cache_stats_summary_entries_label), value = count.toString())
+            SummaryRow(label = stringResource(R.string.cache_stats_summary_total_size_label), value = formatBytes(totalBytes))
+            SummaryRow(label = stringResource(R.string.cache_stats_summary_average_age_label), value = formatAge(avgAgeMillis))
             SummaryRow(
-                label = "Oldest entry",
+                label = stringResource(R.string.cache_stats_summary_oldest_entry_label),
                 value = if (oldest != null) "${oldest.iso3Code} — ${formatAge(oldest.ageMillis)}" else "—"
             )
             SummaryRow(
-                label = "Youngest entry",
+                label = stringResource(R.string.cache_stats_summary_youngest_entry_label),
                 value = if (youngest != null) "${youngest.iso3Code} — ${formatAge(youngest.ageMillis)}" else "—"
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,16 @@
     <string name="data_field_active">Active:</string>
     <string name="data_field_fatality_rate">Fatality Rate:</string>
     <string name="search_field_hint">Search country</string>
+    <string name="cache_stats_title">Cache Statistics</string>
+    <string name="cache_stats_back_button">Back</string>
+    <string name="cache_stats_sort_control_label">Sort by</string>
+    <string name="cache_stats_summary_entries_label">Entries</string>
+    <string name="cache_stats_summary_total_size_label">Total size</string>
+    <string name="cache_stats_summary_average_age_label">Average age</string>
+    <string name="cache_stats_summary_oldest_entry_label">Oldest entry</string>
+    <string name="cache_stats_summary_youngest_entry_label">Youngest entry</string>
+    <string name="sort_option_iso_code_asc">ISO Code (up)</string>
+    <string name="sort_option_iso_code_desc">ISO Code (down)</string>
+    <string name="sort_option_age_asc">Age (up)</string>
+    <string name="sort_option_age_desc">Age (down)</string>
 </resources>


### PR DESCRIPTION
## Summary

All user-visible strings in `CacheStatsScreen` were hardcoded English literals, making the screen impossible to localise while every other screen in the app used `stringResource()` consistently.

**Moved to `strings.xml`:**
- TopAppBar title (`"Cache Statistics"`) and back button `contentDescription` (`"Back"`)
- `SortControl` dropdown label (`"Sort by"`)
- All five `CacheStatsSummaryTable` row labels (`"Entries"`, `"Total size"`, `"Average age"`, `"Oldest entry"`, `"Youngest entry"`)

**`SortOption` enum redesigned:**
- Replaced `val label: String` (hardcoded) with `@Composable abstract fun label(): String`
- Each enum constant overrides `label()` to return its string via `stringResource()`, which respects the device locale
- Call sites updated from `option.label` / `selected.label` to `option.label()` / `selected.label()`

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual: CacheStats screen displays all labels correctly in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)