### PR TITLE
fix: add Role.Button and 48dp touch target to GlobalRegionIcon

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/GlobalRegionIcon.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/GlobalRegionIcon.kt
@@ -1,6 +1,7 @@
 package com.rodbailey.covid.presentation.main
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.Icon
@@ -8,7 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.rodbailey.covid.R
 
 /**
@@ -21,8 +24,9 @@ fun GlobalRegionIcon(clickCallback: () -> Unit) {
         imageVector = Icons.Default.AccountCircle,
         contentDescription = stringResource(R.string.region_global),
         modifier = Modifier
-            .clickable(onClick = clickCallback)
+            .clickable(role = Role.Button, onClick = clickCallback)
             .testTag(MainScreenTag.TAG_ICON_GLOBAL.tag)
+            .size(48.dp)
     )
 }
 

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material3.Icon
@@ -29,7 +30,6 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
-            .height(48.dp)
             .semantics(mergeDescendants = true) {}
             .clickable(
                 role = Role.Button,
@@ -37,7 +37,7 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
             )
     ) {
         Icon(
-            modifier = Modifier.padding(start = 16.dp, end = 8.dp),
+            modifier = Modifier.padding(start = 8.dp, end = 8.dp).size(48.dp),
             imageVector = Icons.Default.AccountBox,
             contentDescription = null   // decorative; region name from Text labels the row
         )


### PR DESCRIPTION
## Summary

- `GlobalRegionIcon` used a bare `Icon` with `.clickable()` — no semantic role and no guaranteed 48dp touch target
- Added `role = Role.Button` to `.clickable()` so TalkBack announces "button, double tap to activate"
- Added `.size(48.dp)` to meet the Material Design minimum interactive target size
- Also refines `RegionSearchResultItem`: moves the 48dp sizing to the `Icon` rather than the `Row` height, and adjusts start padding accordingly

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)
- [ ] Manual with TalkBack: tap the global icon in the search field trailing slot — confirm TalkBack announces "Global, button, double tap to activate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)