### PR TITLE
chore: remove unused string resource and fix MainScreenContent indentation

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -170,72 +170,74 @@ fun MainScreenContent(
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-                // Search text field with global icon at right
-                TextField(
-                    value = uiState.searchText,
-                    onValueChange = onSearchTextChanged,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(MainScreenTag.TAG_TEXT_SEARCH.tag),
-                    trailingIcon = {
-                        GlobalRegionIcon(clickCallback = onGlobalClicked)
-                    },
-                    placeholder = { Text(text = stringResource(R.string.search_field_hint)) }
-                )
+            // Search text field with global icon at right
+            TextField(
+                value = uiState.searchText,
+                onValueChange = onSearchTextChanged,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(MainScreenTag.TAG_TEXT_SEARCH.tag),
+                trailingIcon = {
+                    GlobalRegionIcon(clickCallback = onGlobalClicked)
+                },
+                placeholder = { Text(text = stringResource(R.string.search_field_hint)) }
+            )
 
-                // Tracks progress of region list loading
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .testTag(MainScreenTag.TAG_PROGRESS_SEARCH.tag)
-                        .fillMaxWidth()
-                        .height(16.dp)
-                        .alpha(if (uiState.matchingRegions is Loading) 1f else 0f)
-                        .then(if (uiState.matchingRegions !is Loading) Modifier.semantics { hideFromAccessibility() } else Modifier)
-                        .padding(bottom = 12.dp),
-                    color = MaterialTheme.colorScheme.secondary,
-                    trackColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            // Tracks progress of region list loading
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .testTag(MainScreenTag.TAG_PROGRESS_SEARCH.tag)
+                    .fillMaxWidth()
+                    .height(16.dp)
+                    .alpha(if (uiState.matchingRegions is Loading) 1f else 0f)
+                    .then(if (uiState.matchingRegions !is Loading) Modifier.semantics { hideFromAccessibility() } else Modifier)
+                    .padding(bottom = 12.dp),
+                color = MaterialTheme.colorScheme.secondary,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant
+            )
 
-                // List of countries that match current contents of search field
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .testTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
-                ) {
-                    when (val regions = uiState.matchingRegions) {
-                        is Success -> items(regions.data, key = { it.iso3Code }) { region ->
-                            val clickCallback = remember(region, onRegionClicked) { { onRegionClicked(region) } }
-                            RegionSearchResultItem(
-                                region = region,
-                                clickCallback = clickCallback
-                            )
-                        }
-                        else -> {}
+            // List of countries that match current contents of search field
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .testTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
+            ) {
+                when (val regions = uiState.matchingRegions) {
+                    is Success -> items(regions.data, key = { it.iso3Code }) { region ->
+                        val clickCallback =
+                            remember(region, onRegionClicked) { { onRegionClicked(region) } }
+                        RegionSearchResultItem(
+                            region = region,
+                            clickCallback = clickCallback
+                        )
                     }
-                }
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Data panel shows covid stats for current country or global.
-                // Clicking on the data panel collapses it.
-                // lastVisibleState retains the most recent non-closed state so that
-                // RegionDataPanel holds its content during the exit animation rather
-                // than blanking immediately when dataPanelUIState becomes DataPanelClosed.
-                var lastVisibleState by remember { mutableStateOf(uiState.dataPanelUIState) }
-                LaunchedEffect(uiState.dataPanelUIState) {
-                    if (uiState.dataPanelUIState !is DataPanelClosed) {
-                        lastVisibleState = uiState.dataPanelUIState
-                    }
-                }
-                AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
-                    RegionDataPanel(
-                        dataPanelUIState = lastVisibleState,
-                        clickCallback = onDataPanelCollapsed
-                    )
+                    else -> {}
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Data panel shows covid stats for current country or global.
+            // Clicking on the data panel collapses it.
+            // lastVisibleState retains the most recent non-closed state so that
+            // RegionDataPanel holds its content during the exit animation rather
+            // than blanking immediately when dataPanelUIState becomes DataPanelClosed.
+            var lastVisibleState by remember { mutableStateOf(uiState.dataPanelUIState) }
+            LaunchedEffect(uiState.dataPanelUIState) {
+                if (uiState.dataPanelUIState !is DataPanelClosed) {
+                    lastVisibleState = uiState.dataPanelUIState
+                }
+            }
+            AnimatedVisibility(visible = uiState.dataPanelUIState is DataPanelOpenWithData || uiState.dataPanelUIState is DataPanelOpenWithLoading) {
+                RegionDataPanel(
+                    dataPanelUIState = lastVisibleState,
+                    clickCallback = onDataPanelCollapsed
+                )
+            }
         }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="no_data_available_for">No data available for \"%1$s\".</string>
     <string name="failed_to_load_country_list">Failed to load country list.</string>
     <string name="region_global">Global</string>
-    <string name="region_icon_content_description">Icon</string>
+
     <string name="data_field_confirmed">Confirmed:</string>
     <string name="data_field_deaths">Deaths:</string>
     <string name="data_field_active">Active:</string>


### PR DESCRIPTION
## Summary

Two housekeeping fixes:

**Remove `region_icon_content_description`**
The string (`"Icon"`) was used as the `Icon`'s `contentDescription` in `RegionSearchResultItem`. PR #87 set `contentDescription = null` on that icon (it is decorative within a labelled clickable row), leaving the string unreferenced. Confirmed no other callers before removal.

**Fix indentation in `MainScreenContent`**
The `Column`'s children had one extra level of indentation left over from when the `CovidTheme { }` wrapper was removed in PR #88. Realigned to match standard Kotlin/Compose style.

## Test plan

- [ ] All 58 instrumented tests pass (`./gradlew connectedAndroidTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)