### PR TITLE
test: add triple-tap navigation test to MainUITest

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -265,4 +265,18 @@ class MainUITest {
         rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
     }
 
+    @Test
+    fun triple_tap_navigates_to_cache_stats_screen() {
+        // PointerEventPass.Initial means the triple-tap modifier intercepts every press
+        // before children, so three quick clicks anywhere on the screen will trigger it.
+        // The search field is used as a reliable always-present tap target.
+        val searchField = rule.onNodeWithTag(MainScreenTag.TAG_TEXT_SEARCH.tag)
+        searchField.performClick()
+        searchField.performClick()
+        searchField.performClick()
+
+        rule.waitForIdle()
+        rule.onNodeWithText("Cache Statistics").assertIsDisplayed()
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds a test verifying that three rapid taps anywhere on the main screen navigate to `CacheStatsScreen`. This was the only untested navigation path in the app.

The triple-tap modifier uses `PointerEventPass.Initial` to intercept every screen press before children handle it, so three `performClick()` calls on the search field (a reliable, always-present target) are sufficient to trigger `onTripleTap` and drive navigation. The test asserts the `"Cache Statistics"` title is visible after the three taps.

## Test plan

- [ ] All 76 instrumented tests pass (`./gradlew connectedAndroidTest`) — 75 existing + 1 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)