### PR TITLE
test: add rotation tests for MainScreen and CacheStatsScreen

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreenRotationTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreenRotationTest.kt
@@ -1,0 +1,95 @@
+package com.rodbailey.covid.presentation.cachestats
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.rodbailey.covid.data.repo.CovidRepository
+import com.rodbailey.covid.presentation.core.MainActivity
+import com.rodbailey.covid.presentation.main.MainScreenTag
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Verifies that CacheStatsViewModel-owned state (sortOption) survives a configuration change.
+ * Navigation to CacheStatsScreen is performed via triple-tap in @Before so that the real
+ * CacheStatsViewModel is in play (as opposed to CacheStatsUITest which uses a stateless
+ * composable with no ViewModel).
+ */
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+@HiltAndroidTest
+class CacheStatsScreenRotationTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    @Inject
+    lateinit var fakeCovidRepository: CovidRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        // Navigate to CacheStatsScreen via triple-tap on the search field.
+        // PointerEventPass.Initial ensures the triple-tap modifier intercepts all three
+        // presses before the search field handles them.
+        val searchField = rule.onNodeWithTag(MainScreenTag.TAG_TEXT_SEARCH.tag)
+        searchField.performClick()
+        searchField.performClick()
+        searchField.performClick()
+        rule.waitForIdle()
+    }
+
+    @Test
+    fun cache_stats_title_visible_after_rotation() {
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        rule.onNodeWithText("Cache Statistics").assertIsDisplayed()
+    }
+
+    @Test
+    fun back_button_visible_after_rotation() {
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        rule.onNodeWithContentDescription("Back").assertIsDisplayed()
+    }
+
+    @Test
+    fun summary_table_visible_after_rotation() {
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        rule.onNodeWithText("Entries").assertIsDisplayed()
+    }
+
+    @Test
+    fun sort_option_survives_rotation() {
+        // Change the sort option from the default (ISO Code up) to Age (up)
+        rule.onNodeWithText("ISO Code (up)").performClick()
+        rule.onAllNodesWithText("Age (up)").onFirst().performClick()
+        rule.waitForIdle()
+
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        // sortOption is held in CacheStatsViewModel (MutableStateFlow) — survives rotation
+        rule.onNodeWithText("Age (up)").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainScreenRotationTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainScreenRotationTest.kt
@@ -1,0 +1,101 @@
+package com.rodbailey.covid.presentation.main
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.rodbailey.covid.data.FakeRegions
+import com.rodbailey.covid.data.repo.CovidRepository
+import com.rodbailey.covid.presentation.core.MainActivity
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Verifies that ViewModel-owned state (searchText, dataPanelUIState) survives a configuration
+ * change (simulated via ActivityScenario.recreate()) while ephemeral composable state is
+ * intentionally discarded.
+ */
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+@HiltAndroidTest
+class MainScreenRotationTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    @Inject
+    lateinit var fakeCovidRepository: CovidRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun search_text_survives_rotation() {
+        rule.onNodeWithTag(MainScreenTag.TAG_TEXT_SEARCH.tag).performTextInput("Brazil")
+        rule.waitForIdle()
+
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        // Search text is held in MainViewModel.searchText (MutableStateFlow) — survives rotation
+        rule.onNodeWithTag(MainScreenTag.TAG_TEXT_SEARCH.tag)
+            .assertTextContains("Brazil")
+    }
+
+    @Test
+    fun data_panel_open_state_survives_rotation() {
+        // Open the data panel with global stats
+        rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
+        rule.waitForIdle()
+
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        // dataPanelUIState is held in MainViewModel (MutableStateFlow) — panel stays open
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertIsDisplayed()
+        rule.onNodeWithTag(useUnmergedTree = true, testTag = MainScreenTag.TAG_CARD_TITLE.tag)
+            .assertTextContains(FakeRegions.GLOBAL_REGION.name)
+    }
+
+    @Test
+    fun data_panel_closed_state_survives_rotation() {
+        // Open then close the data panel
+        rule.onNodeWithTag(MainScreenTag.TAG_ICON_GLOBAL.tag).performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).performClick()
+        rule.waitForIdle()
+
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        // Panel was closed before rotation — should remain closed
+        rule.onNodeWithTag(MainScreenTag.TAG_CARD.tag).assertDoesNotExist()
+    }
+
+    @Test
+    fun region_list_visible_after_rotation() {
+        // Wait for region list to load from FakeCovidRepository
+        rule.waitForIdle()
+
+        rule.activityRule.scenario.recreate()
+        rule.waitForIdle()
+
+        // Region data is re-emitted from the repository flow after recreation
+        rule.onNodeWithText(FakeRegions.FIRST_REGION_BY_NAME.name).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MainScreenRotationTest` — verifies that `searchText` and `dataPanelUIState` (ViewModel-owned state) survive a configuration change simulated via `ActivityScenario.recreate()`
- Adds `CacheStatsScreenRotationTest` — verifies that `sortOption` (ViewModel-owned state) survives rotation; navigates to `CacheStatsScreen` via triple-tap in `@Before`

## Test plan
- [x] `MainScreenRotationTest` — 4/4 passing on Pixel 3 (Android 12)
- [x] `CacheStatsScreenRotationTest` — 4/4 passing on Pixel 3 (Android 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)