### PR TITLE
fix: use WhileSubscribed(5_000) to avoid Loading flash on rotation

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/MainViewModel.kt
@@ -123,7 +123,7 @@ class MainViewModel @Inject constructor(
         )
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
+        started = SharingStarted.WhileSubscribed(5_000),
         initialValue = UIState()
     )
 


### PR DESCRIPTION
## Summary
- Changes `SharingStarted.WhileSubscribed()` to `SharingStarted.WhileSubscribed(5_000)` in `MainViewModel.uiState`
- The 5-second grace period keeps the upstream `combine` alive through the ~1 second rotation window, so `onStart` in `asResult()` never re-fires during rotation and `Result.Loading` is never briefly re-emitted into `uiState`
- Without the timeout, the upstream stops the moment the old Activity unsubscribes, causing a `Loading` flash before Room re-emits the cached data

## Test plan
- [x] All 84 instrumented tests pass on Pixel 3 (Android 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)