### PR TITLE
perf: improve Compose stability and reduce unnecessary recompositions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,4 +173,5 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.9.8")
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8")
 }

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsUITest.kt
@@ -13,6 +13,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.rodbailey.covid.data.repo.CacheEntry
 import com.rodbailey.covid.presentation.theme.CovidTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -25,14 +28,14 @@ class CacheStatsUITest {
     @get:Rule
     val rule = createAndroidComposeRule<ComponentActivity>()
 
-    private val threeEntries = listOf(
+    private val threeEntries = persistentListOf(
         CacheEntry("AFG", 2_400_000L),  // ~40 minutes old
         CacheEntry("AUS",   600_000L),  // ~10 minutes old
         CacheEntry("BRA", 3_600_000L),  // ~60 minutes old
     )
 
     private fun setContent(
-        entries: List<CacheEntry> = threeEntries,
+        entries: ImmutableList<CacheEntry> = threeEntries,
         sortOption: SortOption = SortOption.ISO_CODE_ASC,
         onSortOptionSelected: (SortOption) -> Unit = {},
         onDismiss: () -> Unit = {}
@@ -79,7 +82,7 @@ class CacheStatsUITest {
 
     @Test
     fun empty_cache_shows_zero_entries_in_summary() {
-        setContent(entries = emptyList())
+        setContent(entries = persistentListOf())
         // The summary "Entries" row value is "0"
         rule.onNodeWithText("0").assertIsDisplayed()
     }
@@ -131,7 +134,7 @@ class CacheStatsUITest {
 
     @Test
     fun empty_cache_shows_no_bar_labels() {
-        setContent(entries = emptyList())
+        setContent(entries = persistentListOf())
         rule.onNodeWithText("AFG").assertDoesNotExist()
         rule.onNodeWithText("AUS").assertDoesNotExist()
     }

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -72,6 +72,8 @@ private fun formatBytes(bytes: Int): String = when {
     else -> "$bytes B"
 }
 
+private val ageValueFormatter: (Float) -> String = { formatAge(it.toLong()) }
+
 // ---------------------------------------------------------------------------
 // Sort
 // ---------------------------------------------------------------------------
@@ -207,7 +209,7 @@ fun CacheStatsScreenContent(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(horizontal = 16.dp),
-                valueFormatter = { formatAge(it.toLong()) }
+                valueFormatter = ageValueFormatter
             )
         }
     }

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -40,6 +40,9 @@ import com.rodbailey.covid.R
 import com.rodbailey.covid.data.repo.BYTES_PER_STATS_ROW
 import com.rodbailey.covid.data.repo.CacheEntry
 import com.rodbailey.covid.presentation.Result
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 // ---------------------------------------------------------------------------
 // Age formatting
@@ -115,7 +118,7 @@ fun CacheStatsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val entries = (uiState.entries as? Result.Success)?.data ?: emptyList()
+    val entries = (uiState.entries as? Result.Success)?.data?.toImmutableList() ?: persistentListOf()
 
     CacheStatsScreenContent(
         entries = entries,
@@ -145,7 +148,7 @@ fun CacheStatsScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CacheStatsScreenContent(
-    entries: List<CacheEntry>,
+    entries: ImmutableList<CacheEntry>,
     sortOption: SortOption,
     onSortOptionSelected: (SortOption) -> Unit,
     onDismiss: () -> Unit
@@ -270,7 +273,7 @@ private fun SortControl(
 
 @Composable
 fun CacheStatsSummaryTable(
-    entries: List<CacheEntry>,
+    entries: ImmutableList<CacheEntry>,
     modifier: Modifier = Modifier
 ) {
     val count = remember(entries) { entries.size }
@@ -323,7 +326,7 @@ private fun SummaryRow(label: String, value: String) {
 // Previews
 // ---------------------------------------------------------------------------
 
-private val previewEntries = listOf(
+private val previewEntries = persistentListOf(
     CacheEntry("AFG", 2_478_000L),
     CacheEntry("AUS", 1_620_000L),
     CacheEntry("BRA",   660_000L),
@@ -348,7 +351,7 @@ private fun PreviewCacheStatsWithData() {
 @Composable
 private fun PreviewCacheStatsEmpty() {
     CacheStatsScreenContent(
-        entries = emptyList(),
+        entries = persistentListOf(),
         sortOption = SortOption.ISO_CODE_ASC,
         onSortOptionSelected = {},
         onDismiss = {}

--- a/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/core/UIText.kt
@@ -3,12 +3,14 @@ package com.rodbailey.covid.presentation.core
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.res.stringResource
 
 /**
  * Provides a way of passing a string resource from ViewModel to UI without
  * having access to application context at construction time
  */
+@Immutable
 sealed class UIText {
 
     /**

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
@@ -26,6 +26,8 @@ import com.rodbailey.covid.domain.ReportData
 import com.rodbailey.covid.presentation.MainViewModel
 import com.rodbailey.covid.presentation.core.UIText
 
+private val EmptyReportData = ReportData()
+
 
 /**
  * Panel of covid statistics for a particular region. Shows confirmed, deaths, active and
@@ -40,11 +42,11 @@ fun RegionDataPanel(
     dataPanelUIState: MainViewModel.DataPanelUIState,
     clickCallback: () -> Unit
 ) {
+    val openWithData = dataPanelUIState as? MainViewModel.DataPanelUIState.DataPanelOpenWithData
     val isLoading = dataPanelUIState is MainViewModel.DataPanelUIState.DataPanelOpenWithLoading
-    val title = (dataPanelUIState as? MainViewModel.DataPanelUIState.DataPanelOpenWithData)
-        ?.reportDataTitle?.asString() ?: ""
-    val reportData = (dataPanelUIState as? MainViewModel.DataPanelUIState.DataPanelOpenWithData)
-        ?.reportData ?: ReportData()
+
+    val title = openWithData?.reportDataTitle?.asString() ?: ""
+    val reportData = openWithData?.reportData ?: EmptyReportData
 
     Card(
         onClick = clickCallback, modifier = Modifier


### PR DESCRIPTION
## Summary
- Annotate `UIText` with `@Immutable` so the Compose compiler treats `DataPanelUIState` as stable, making `RegionDataPanel` skippable
- Hoist `ReportData()` default to a top-level constant in `RegionDataPanel` to avoid allocating a new instance on every recomposition
- Switch `entries` parameter in `CacheStatsScreenContent` and `CacheStatsSummaryTable` from `List<CacheEntry>` to `ImmutableList<CacheEntry>` (via `kotlinx-collections-immutable:0.3.8`) so both composables are skippable
- Hoist the `valueFormatter` lambda in `CacheStatsScreenContent` to a top-level constant to avoid allocating a new instance on every recomposition

## Test plan
- [x] All 84 instrumented tests pass on Pixel 3 (Android 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)