### PR TITLE
feat: propagate Region surrogate key through domain layer

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/data/FakeRegions.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/data/FakeRegions.kt
@@ -8,7 +8,7 @@ import com.rodbailey.covid.domain.ReportData
  */
 object FakeRegions {
 
-    val GLOBAL_REGION = Region("___", "Global")
+    val GLOBAL_REGION = Region(iso3Code = "___", name = "Global")
     val GLOBAL_REGION_STATS = ReportData(
         confirmed = 88L,
         deaths = 66L,
@@ -17,386 +17,388 @@ object FakeRegions {
         fatalityRate = 9.5F
     )
 
-    val REGIONS = mapOf(
-        Region("CHN", "China") to ReportData(
+    val REGIONS: Map<Region, ReportData> = mapOf(
+        Region(iso3Code = "CHN", name = "China") to ReportData(
             confirmed = 10L,
             deaths = 20L,
             recovered = 30L,
             active = 40L,
             fatalityRate = 0.5F
         ),
-        Region("TWN", "Taipei and environs") to ReportData(
+        Region(iso3Code = "TWN", name = "Taipei and environs") to ReportData(
             confirmed = 5L,
             deaths = 7L,
             recovered = 9L,
             active = 11L,
             fatalityRate = 1.3F
         ),
-        Region("USA", "US") to ReportData(
+        Region(iso3Code = "USA", name = "US") to ReportData(
             confirmed = 30L,
             deaths = 50L,
             recovered = 70L,
             active = 90L,
             fatalityRate = 3.5F
         ),
-        Region("JPN", "Japan") to ReportData(
+        Region(iso3Code = "JPN", name = "Japan") to ReportData(
             confirmed = 60L,
             deaths = 70L,
             recovered = 380L,
             active = 430L,
             fatalityRate = 0.55F
         ),
-        Region("THA", "Thailand") to ReportData(
+        Region(iso3Code = "THA", name = "Thailand") to ReportData(
             confirmed = 305L,
             deaths = 405L,
             recovered = 505L,
             active = 605L,
             fatalityRate = 0.75F
         ),
-        Region("KOR", "Korea, South") to ReportData(
+        Region(iso3Code = "KOR", name = "Korea, South") to ReportData(
             confirmed = 16L,
             deaths = 26L,
             recovered = 36L,
             active = 46L,
             fatalityRate = 0.56F
         ),
-        Region("SGP", "Singapore") to ReportData(
+        Region(iso3Code = "SGP", name = "Singapore") to ReportData(
             confirmed = 10L,
             deaths = 20L,
             recovered = 30L,
             active = 40L,
             fatalityRate = 0.5F
         ),
-        Region("PHL", "Philippines") to ReportData(
+        Region(iso3Code = "PHL", name = "Philippines") to ReportData(
             confirmed = 1000L,
             deaths = 2000L,
             recovered = 3000L,
             active = 4000L,
             fatalityRate = 50.5F
         ),
-        Region("MYS", "Malaysia") to ReportData(
+        Region(iso3Code = "MYS", name = "Malaysia") to ReportData(
             confirmed = 111L,
             deaths = 222L,
             recovered = 333L,
             active = 444L,
             fatalityRate = 5.55F
         ),
-        Region("VNM", "Vietnam") to ReportData(
+        Region(iso3Code = "VNM", name = "Vietnam") to ReportData(
             confirmed = 108L,
             deaths = 208L,
             recovered = 308L,
             active = 408L,
             fatalityRate = 8.58F
         ),
-        Region("AUS", "Australia") to ReportData(
+        Region(iso3Code = "AUS", name = "Australia") to ReportData(
             confirmed = 10000L,
             deaths = 20000L,
             recovered = 30000L,
             active = 40000L,
             fatalityRate = 18.55F
         ),
-        Region("MEX", "Mexico") to ReportData(
+        Region(iso3Code = "MEX", name = "Mexico") to ReportData(
             confirmed = 810L,
             deaths = 820L,
             recovered = 830L,
             active = 840L,
             fatalityRate = 80.5F
         ),
-        Region("BRA", "Brazil") to ReportData(
+        Region(iso3Code = "BRA", name = "Brazil") to ReportData(
             confirmed = 109L,
             deaths = 209L,
             recovered = 309L,
             active = 409L,
             fatalityRate = 9.5F
         ),
-        Region("COL", "Colombia") to ReportData(
+        Region(iso3Code = "COL", name = "Colombia") to ReportData(
             confirmed = 11L,
             deaths = 120L,
             recovered = 130L,
             active = 140L,
             fatalityRate = 10.5F
         ),
-        Region("FRA", "France") to ReportData(
+        Region(iso3Code = "FRA", name = "France") to ReportData(
             confirmed = 1077L,
             deaths = 2077L,
             recovered = 30777L,
             active = 4077L,
             fatalityRate = 7.57F
         ),
-        Region("NPL", "Nepal") to ReportData(
+        Region(iso3Code = "NPL", name = "Nepal") to ReportData(
             confirmed = 1033L,
             deaths = 2033L,
             recovered = 3033L,
             active = 4033L,
             fatalityRate = 33.5F
         ),
-        Region("CAN", "Canada") to ReportData(
+        Region(iso3Code = "CAN", name = "Canada") to ReportData(
             confirmed = 4000L,
             deaths = 400L,
             recovered = 40L,
             active = 44L,
             fatalityRate = 4.5F
         ),
-        Region("KHM", "Cambodia") to ReportData(
+        Region(iso3Code = "KHM", name = "Cambodia") to ReportData(
             confirmed = 510L,
             deaths = 520L,
             recovered = 530L,
             active = 540L,
             fatalityRate = 5.5F
         ),
-        Region("LKA", "Sri Lanka") to ReportData(
+        Region(iso3Code = "LKA", name = "Sri Lanka") to ReportData(
             confirmed = 710L,
             deaths = 720L,
             recovered = 730L,
             active = 740L,
             fatalityRate = 7.5F
         ),
-        Region("CIV", "Cote d'Ivoire") to ReportData(
+        Region(iso3Code = "CIV", name = "Cote d'Ivoire") to ReportData(
             confirmed = 222L,
             deaths = 333L,
             recovered = 444L,
             active = 555L,
             fatalityRate = 6.6F
         ),
-        Region("DEU", "Germany") to ReportData(
+        Region(iso3Code = "DEU", name = "Germany") to ReportData(
             confirmed = 7010L,
             deaths = 7020L,
             recovered = 7030L,
             active = 7040L,
             fatalityRate = 7.57F
         ),
-        Region("FIN", "Finland") to ReportData(
+        Region(iso3Code = "FIN", name = "Finland") to ReportData(
             confirmed = 123L,
             deaths = 234L,
             recovered = 345L,
             active = 456L,
             fatalityRate = 5.6F
         ),
-        Region("ARE", "United Arab Emirates") to ReportData(
+        Region(iso3Code = "ARE", name = "United Arab Emirates") to ReportData(
             confirmed = 5L,
             deaths = 25L,
             recovered = 355L,
             active = 4555L,
             fatalityRate = 55.5F
         ),
-        Region("IND", "India") to ReportData(
+        Region(iso3Code = "IND", name = "India") to ReportData(
             confirmed = 1L,
             deaths = 2L,
             recovered = 3L,
             active = 4L,
             fatalityRate = 0.5F
         ),
-        Region("ITA", "Italy") to ReportData(
+        Region(iso3Code = "ITA", name = "Italy") to ReportData(
             confirmed = 60L,
             deaths = 70L,
             recovered = 80L,
             active = 90L,
             fatalityRate = 10.5F
         ),
-        Region("GBR", "United Kingdom") to ReportData(
+        Region(iso3Code = "GBR", name = "United Kingdom") to ReportData(
             confirmed = 4L,
             deaths = 16L,
             recovered = 64L,
             active = 128L,
             fatalityRate = 4.5F
         ),
-        Region("RUS", "Russia") to ReportData(
+        Region(iso3Code = "RUS", name = "Russia") to ReportData(
             confirmed = 106L,
             deaths = 720L,
             recovered = 308L,
             active = 490L,
             fatalityRate = 1.5F
         ),
-        Region("SWE", "Sweden") to ReportData(
+        Region(iso3Code = "SWE", name = "Sweden") to ReportData(
             confirmed = 1011L,
             deaths = 2220L,
             recovered = 3330L,
             active = 4044L,
             fatalityRate = 56.5F
         ),
-        Region("ESP", "Spain") to ReportData(
+        Region(iso3Code = "ESP", name = "Spain") to ReportData(
             confirmed = 1L,
             deaths = 10L,
             recovered = 100L,
             active = 10000L,
             fatalityRate = 1.51F
         ),
-        Region("BEL", "Belgium") to ReportData(
+        Region(iso3Code = "BEL", name = "Belgium") to ReportData(
             confirmed = 303L,
             deaths = 404L,
             recovered = 505L,
             active = 606L,
             fatalityRate = 0.75F
         ),
-        Region("Others", "Others") to ReportData(
+        Region(iso3Code = "Others", name = "Others") to ReportData(
             confirmed = 810L,
             deaths = 820L,
             recovered = 380L,
             active = 480L,
             fatalityRate = 0.85F
         ),
-        Region("EGY", "Egypt") to ReportData(
+        Region(iso3Code = "EGY", name = "Egypt") to ReportData(
             confirmed = 109L,
             deaths = 920L,
             recovered = 390L,
             active = 409L,
             fatalityRate = 0.95F
         ),
-        Region("IRN", "Iran") to ReportData(
+        Region(iso3Code = "IRN", name = "Iran") to ReportData(
             confirmed = 10001L,
             deaths = 20002L,
             recovered = 30003L,
             active = 40004L,
             fatalityRate = 0.55F
         ),
-        Region("ISR", "Israel") to ReportData(
+        Region(iso3Code = "ISR", name = "Israel") to ReportData(
             confirmed = 10002L,
             deaths = 20003L,
             recovered = 30004L,
             active = 40005L,
             fatalityRate = 0.56F
         ),
-        Region("LBN", "Lebanon") to ReportData(
+        Region(iso3Code = "LBN", name = "Lebanon") to ReportData(
             confirmed = 110L,
             deaths = 2110L,
             recovered = 1130L,
             active = 4101L,
             fatalityRate = 1.5F
         ),
-        Region("IRQ", "Iraq") to ReportData(
+        Region(iso3Code = "IRQ", name = "Iraq") to ReportData(
             confirmed = 5L,
             deaths = 25L,
             recovered = 580L,
             active = 430L,
             fatalityRate = 3.5F
         ),
-        Region("OMN", "Oman") to ReportData(
+        Region(iso3Code = "OMN", name = "Oman") to ReportData(
             confirmed = 190L,
             deaths = 290L,
             recovered = 390L,
             active = 490L,
             fatalityRate = 0.98F
         ),
-        Region("AFG", "Afghanistan") to ReportData(
+        Region(iso3Code = "AFG", name = "Afghanistan") to ReportData(
             confirmed = 910L,
             deaths = 920L,
             recovered = 930L,
             active = 940L,
             fatalityRate = 0.95F
         ),
-        Region("BHR", "Bahrain") to ReportData(
+        Region(iso3Code = "BHR", name = "Bahrain") to ReportData(
             confirmed = 1860L,
             deaths = 2860L,
             recovered = 3860L,
             active = 4860L,
             fatalityRate = 08.5F
         ),
-        Region("KWT", "Kuwait") to ReportData(
+        Region(iso3Code = "KWT", name = "Kuwait") to ReportData(
             confirmed = 10L,
             deaths = 13L,
             recovered = 33L,
             active = 46L,
             fatalityRate = 5.5F
         ),
-        Region("AUT", "Austria") to ReportData(
+        Region(iso3Code = "AUT", name = "Austria") to ReportData(
             confirmed = 1870L,
             deaths = 2870L,
             recovered = 3870L,
             active = 4870L,
             fatalityRate = 8.57F
         ),
-        Region("DZA", "Algeria") to ReportData(
+        Region(iso3Code = "DZA", name = "Algeria") to ReportData(
             confirmed = 10L,
             deaths = 110L,
             recovered = 2230L,
             active = 330L,
             fatalityRate = 4.5F
         ),
-        Region("HRV", "Croatia") to ReportData(
+        Region(iso3Code = "HRV", name = "Croatia") to ReportData(
             confirmed = 19L,
             deaths = 29L,
             recovered = 39L,
             active = 49L,
             fatalityRate = 0.59F
         ),
-        Region("CHE", "Switzerland") to ReportData(
+        Region(iso3Code = "CHE", name = "Switzerland") to ReportData(
             confirmed = 1055L,
             deaths = 2550L,
             recovered = 3055L,
             active = 4550L,
             fatalityRate = 5.5F
         ),
-        Region("PAK", "Pakistan") to ReportData(
+        Region(iso3Code = "PAK", name = "Pakistan") to ReportData(
             confirmed = 1009L,
             deaths = 2010L,
             recovered = 3020L,
             active = 4030L,
             fatalityRate = 7.5F
         ),
-        Region("GEO", "Georgia") to ReportData(
+        Region(iso3Code = "GEO", name = "Georgia") to ReportData(
             confirmed = 13L,
             deaths = 2033L,
             recovered = 3330L,
             active = 4034L,
             fatalityRate = 2.5F
         ),
-        Region("GRC", "Greece") to ReportData(
+        Region(iso3Code = "GRC", name = "Greece") to ReportData(
             confirmed = 10L,
             deaths = 200L,
             recovered = 300L,
             active = 400L,
             fatalityRate = 8.5F
         ),
-        Region("MKD", "North Macedonia") to ReportData(
+        Region(iso3Code = "MKD", name = "North Macedonia") to ReportData(
             confirmed = 505L,
             deaths = 606L,
             recovered = 707L,
             active = 808L,
             fatalityRate = 9.5F
         ),
-        Region("NOR", "Norway") to ReportData(
+        Region(iso3Code = "NOR", name = "Norway") to ReportData(
             confirmed = 103L,
             deaths = 203L,
             recovered = 303L,
             active = 403L,
             fatalityRate = 0.35F
         ),
-        Region("ROU", "Romania") to ReportData(
+        Region(iso3Code = "ROU", name = "Romania") to ReportData(
             confirmed = 9910L,
             deaths = 9920L,
             recovered = 9930L,
             active = 9940L,
             fatalityRate = 99.5F
         ),
-        Region("DNK", "Denmark") to ReportData(
+        Region(iso3Code = "DNK", name = "Denmark") to ReportData(
             confirmed = 102L,
             deaths = 203L,
             recovered = 304L,
             active = 405L,
             fatalityRate = 0.56F
         ),
-        Region("EST", "Estonia") to ReportData(
+        Region(iso3Code = "EST", name = "Estonia") to ReportData(
             confirmed = 110L,
             deaths = 210L,
             recovered = 310L,
             active = 410L,
             fatalityRate = 1.5F
         ),
-        Region("NLD", "Netherlands") to ReportData(
+        Region(iso3Code = "NLD", name = "Netherlands") to ReportData(
             confirmed = 1910L,
             deaths = 2920L,
             recovered = 3930L,
             active = 4940L,
             fatalityRate = 4.9F
         ),
-        Region("SMR", "San Marino") to ReportData(
+        Region(iso3Code = "SMR", name = "San Marino") to ReportData(
             confirmed = 4L,
             deaths = 3L,
             recovered = 2L,
             active = 1L,
             fatalityRate = 17.9F
         )
-    )
+    ).entries.mapIndexed { idx, (region, data) ->
+        region.copy(id = idx + 1) to data
+    }.toMap()
 
     fun regionByIso3Code(iso3Code:String) : Region {
         return REGIONS.filter { it.key.iso3Code == iso3Code }.keys.first()

--- a/app/src/main/java/com/rodbailey/covid/data/db/RegionEntity.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/RegionEntity.kt
@@ -20,6 +20,7 @@ data class RegionEntity (
 
 fun RegionEntity.toRegion() =
     Region(
+        id = this.id,
         iso3Code = this.iso3code,
         name = this.name
     )

--- a/app/src/main/java/com/rodbailey/covid/domain/Region.kt
+++ b/app/src/main/java/com/rodbailey/covid/domain/Region.kt
@@ -8,13 +8,14 @@ import com.rodbailey.covid.data.repo.RegionCode
  * Geographical region that has a 3 letter ISO code.
  */
 data class Region(
+    val id: Int = 0,
+
     @SerializedName("iso")
     val iso3Code: String,
 
     @SerializedName("name")
     val name: String
-) {
-}
+)
 
 fun Region.toRegionEntity() =
     RegionEntity(

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -204,7 +204,7 @@ fun MainScreenContent(
                     .testTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
             ) {
                 when (val regions = uiState.matchingRegions) {
-                    is Success -> items(regions.data, key = { it.iso3Code }) { region ->
+                    is Success -> items(regions.data, key = { it.id }) { region ->
                         val clickCallback =
                             remember(region, onRegionClicked) { { onRegionClicked(region) } }
                         RegionSearchResultItem(
@@ -245,11 +245,11 @@ fun MainScreenContent(
 // ---------------------------------------------------------------------------
 
 private val previewRegions = listOf(
-    Region("AUS", "Australia"),
-    Region("BRA", "Brazil"),
-    Region("CAN", "Canada"),
-    Region("DEU", "Germany"),
-    Region("IND", "India"),
+    Region(1, "AUS", "Australia"),
+    Region(2, "BRA", "Brazil"),
+    Region(3, "CAN", "Canada"),
+    Region(4, "DEU", "Germany"),
+    Region(5, "IND", "India"),
 )
 
 private val previewReportData = ReportData(

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
@@ -53,7 +53,7 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
 @Composable
 fun RegionSearchResultItemPreview() {
     RegionSearchResultItem(
-        region = Region("ELO", "Electric Light Orchestra")
+        region = Region(iso3Code = "ELO", name = "Electric Light Orchestra")
     ) {
     }
 }


### PR DESCRIPTION
## Summary

- Add `id: Int = 0` field to the `Region` domain model, threading `RegionEntity`'s auto-generated primary key through to the presentation layer
- Update `RegionEntity.toRegion()` to map `id`
- Change `LazyColumn` item key in `MainScreen` from `iso3Code` to `id`
- Fix positional `Region(...)` call in `RegionSearchResultItem` preview to use named args
- Fix `FakeRegions.REGIONS` to assign sequential ids (1…55) via `mapIndexed` so instrumented tests don't crash with duplicate LazyColumn keys

No schema migration required — the `id` column already existed in the `regions` Room table.

## Test plan

- [ ] All 84 instrumented tests pass
- [ ] All 14 unit tests pass
- [ ] App builds and region list loads correctly
- [ ] Tapping a region opens the data panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)