### PR TITLE
feat: add CLEAR button to cache stats screen

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/data/repo/FakeCovidRepository.kt
@@ -6,6 +6,7 @@ import com.rodbailey.covid.domain.Region
 import com.rodbailey.covid.domain.ReportData
 import com.rodbailey.covid.domain.toRegionStats
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -76,13 +77,17 @@ class FakeCovidRepository() : CovidRepository {
         regionsThrowException = value
     }
 
-    /** The list returned by [getCacheEntriesStream]. Defaults to empty. */
-    private var cacheEntries: List<CacheEntry> = emptyList()
+    /** The flow backing [getCacheEntriesStream]. Defaults to empty. */
+    private val _cacheEntries = MutableStateFlow<List<CacheEntry>>(emptyList())
 
     fun setCacheEntries(entries: List<CacheEntry>) {
-        cacheEntries = entries
+        _cacheEntries.value = entries
     }
 
-    override fun getCacheEntriesStream(): Flow<List<CacheEntry>> = flowOf(cacheEntries)
+    override fun getCacheEntriesStream(): Flow<List<CacheEntry>> = _cacheEntries
+
+    override suspend fun clearCache() {
+        _cacheEntries.value = emptyList()
+    }
 
 }

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsUITest.kt
@@ -38,6 +38,7 @@ class CacheStatsUITest {
         entries: ImmutableList<CacheEntry> = threeEntries,
         sortOption: SortOption = SortOption.ISO_CODE_ASC,
         onSortOptionSelected: (SortOption) -> Unit = {},
+        onClearCache: () -> Unit = {},
         onDismiss: () -> Unit = {}
     ) {
         rule.setContent {
@@ -46,6 +47,7 @@ class CacheStatsUITest {
                     entries = entries,
                     sortOption = sortOption,
                     onSortOptionSelected = onSortOptionSelected,
+                    onClearCache = onClearCache,
                     onDismiss = onDismiss
                 )
             }
@@ -74,6 +76,20 @@ class CacheStatsUITest {
         setContent(onDismiss = { dismissed = true })
         rule.onNodeWithContentDescription("Back").performClick()
         assertEquals(true, dismissed)
+    }
+
+    @Test
+    fun clear_button_is_displayed() {
+        setContent()
+        rule.onNodeWithText("CLEAR").assertIsDisplayed()
+    }
+
+    @Test
+    fun clear_button_invokes_on_clear_cache() {
+        var cleared = false
+        setContent(onClearCache = { cleared = true })
+        rule.onNodeWithText("CLEAR").performClick()
+        assertEquals(true, cleared)
     }
 
     // -------------------------------------------------------------------------

--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModelTest.kt
@@ -137,6 +137,34 @@ class CacheStatsViewModelTest {
         }
 
     // -------------------------------------------------------------------------
+    // Clear cache
+    // -------------------------------------------------------------------------
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun clear_cache_results_in_empty_entries() =
+        runTest(UnconfinedTestDispatcher()) {
+            val testEntries = listOf(
+                CacheEntry("AFG", 60_000L),
+                CacheEntry("AUS", 120_000L),
+            )
+            (fakeCovidRepository as FakeCovidRepository).setCacheEntries(testEntries)
+            viewModel = CacheStatsViewModel(fakeCovidRepository, ApplicationProvider.getApplicationContext())
+
+            viewModel.uiState.test {
+                skipItems(1) // skip Result.Loading
+                val beforeClear = awaitItem()
+                Assert.assertEquals(2, (beforeClear.entries as Result.Success).data.size)
+
+                viewModel.clearCache()
+
+                val afterClear = awaitItem()
+                val entries = (afterClear.entries as Result.Success).data
+                Assert.assertTrue("Expected empty list after clear", entries.isEmpty())
+            }
+        }
+
+    // -------------------------------------------------------------------------
     // Single entry edge case
     // -------------------------------------------------------------------------
 

--- a/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsDao.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/db/RegionStatsDao.kt
@@ -15,4 +15,7 @@ interface RegionStatsDao {
 
     @Query("SELECT * FROM stats ORDER BY iso3code COLLATE NOCASE ASC")
     fun getAllStatsStream(): Flow<List<RegionStatsEntity>>
+
+    @Query("DELETE FROM stats")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/CovidRepository.kt
@@ -25,4 +25,7 @@ interface CovidRepository {
      */
     fun getCacheEntriesStream(): Flow<List<CacheEntry>>
 
+    /** Deletes all cached region stats entries. */
+    suspend fun clearCache()
+
 }

--- a/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
+++ b/app/src/main/java/com/rodbailey/covid/data/repo/DefaultCovidRepository.kt
@@ -49,6 +49,10 @@ class DefaultCovidRepository(
             // DAO returns rows ORDER BY iso3code COLLATE NOCASE ASC — no in-memory sort needed
         }
 
+    override suspend fun clearCache() {
+        regionStatsDao.deleteAll()
+    }
+
     private fun codeToApiQueryParam(code: RegionCode): String? {
         return if (code is GlobalCode) {
             null

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -130,6 +131,7 @@ fun CacheStatsScreen(
         entries = entries,
         sortOption = uiState.sortOption,
         onSortOptionSelected = viewModel::setSortOption,
+        onClearCache = viewModel::clearCache,
         onDismiss = onDismiss
     )
 }
@@ -157,6 +159,7 @@ fun CacheStatsScreenContent(
     entries: ImmutableList<CacheEntry>,
     sortOption: SortOption,
     onSortOptionSelected: (SortOption) -> Unit,
+    onClearCache: () -> Unit,
     onDismiss: () -> Unit
 ) {
     BackHandler(onBack = onDismiss)
@@ -176,6 +179,11 @@ fun CacheStatsScreenContent(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.cache_stats_back_button)
                         )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = onClearCache) {
+                        Text(stringResource(R.string.cache_stats_clear_button))
                     }
                 }
             )
@@ -349,6 +357,7 @@ private fun PreviewCacheStatsWithData() {
         entries = previewEntries,
         sortOption = SortOption.ISO_CODE_ASC,
         onSortOptionSelected = {},
+        onClearCache = {},
         onDismiss = {}
     )
 }
@@ -360,6 +369,7 @@ private fun PreviewCacheStatsEmpty() {
         entries = persistentListOf(),
         sortOption = SortOption.ISO_CODE_ASC,
         onSortOptionSelected = {},
+        onClearCache = {},
         onDismiss = {}
     )
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/CacheStatsViewModel.kt
@@ -9,6 +9,7 @@ import com.rodbailey.covid.presentation.Result
 import com.rodbailey.covid.presentation.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,7 +22,7 @@ private const val PREF_SORT_OPTION = "sort_option"
 
 @HiltViewModel
 class CacheStatsViewModel @Inject constructor(
-    repo: CovidRepository,
+    private val repo: CovidRepository,
     @ApplicationContext context: Context
 ) : ViewModel() {
 
@@ -54,5 +55,10 @@ class CacheStatsViewModel @Inject constructor(
     fun setSortOption(option: SortOption) {
         _sortOption.value = option
         prefs.edit().putString(PREF_SORT_OPTION, option.name).apply()
+    }
+
+    /** Deletes all cached region stats entries. The cache entries flow re-emits automatically. */
+    fun clearCache() {
+        viewModelScope.launch { repo.clearCache() }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="sort_option_iso_code_desc">ISO Code (down)</string>
     <string name="sort_option_age_asc">Age (up)</string>
     <string name="sort_option_age_desc">Age (down)</string>
+    <string name="cache_stats_clear_button">CLEAR</string>
 </resources>


### PR DESCRIPTION
## Summary

- Add `deleteAll()` to `RegionStatsDao` and `clearCache()` to `CovidRepository` / `DefaultCovidRepository`
- Add `clearCache()` to `CacheStatsViewModel` — launches a coroutine to delete all cached stats; the Room-backed Flow re-emits an empty list automatically so the UI updates reactively with no extra state management
- Add `CLEAR` `TextButton` to the `TopAppBar` actions slot in `CacheStatsScreenContent`
- Switch `FakeCovidRepository` from `flowOf` to `MutableStateFlow` for cache entries, enabling `clearCache()` to be tested end-to-end
- Add 3 new tests: CLEAR button visible, CLEAR button invokes callback, ViewModel `clearCache()` results in empty entries

## Test plan

- [ ] All 87 instrumented tests pass
- [ ] All 14 unit tests pass
- [ ] Load global and region stats, triple-tap to cache stats, tap CLEAR — bar chart and summary update immediately to empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)