### PR TITLE
test: add scroll-to-bottom test using performScrollToNode

### DIFF
--- a/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
+++ b/app/src/androidTest/java/com/rodbailey/covid/presentation/main/MainUITest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
@@ -87,6 +88,13 @@ class MainUITest {
     fun can_scroll_to_last_country_alphabetically_in_country_list() {
         rule.onNodeWithTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
             .performScrollToIndex(FakeRegions.NUM_REGIONS - 1)
+        rule.onNodeWithText(FakeRegions.LAST_REGION_BY_NAME.name).assertIsDisplayed()
+    }
+
+    @Test
+    fun scrolling_through_country_list_to_bottom_reveals_last_country() {
+        rule.onNodeWithTag(MainScreenTag.TAG_LAZY_COLUMN_SEARCH.tag)
+            .performScrollToNode(hasText(FakeRegions.LAST_REGION_BY_NAME.name))
         rule.onNodeWithText(FakeRegions.LAST_REGION_BY_NAME.name).assertIsDisplayed()
     }
 


### PR DESCRIPTION
## Summary

Adds a new instrumented test that scrolls to the last country in the list by content (`performScrollToNode`) rather than by index (`performScrollToIndex`). This complements the existing scroll test and more closely simulates how a user would naturally scroll through the list.

## Test plan

- [ ] `scrolling_through_country_list_to_bottom_reveals_last_country` passes on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)