### PR TITLE
fix: replace triple-tap with long-press on globe icon to open cache stats

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/GlobalRegionIcon.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/GlobalRegionIcon.kt
@@ -1,6 +1,7 @@
 package com.rodbailey.covid.presentation.main
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
@@ -15,16 +16,23 @@ import androidx.compose.ui.unit.dp
 import com.rodbailey.covid.R
 
 /**
- * Icon at right of search field. When clicked it reveals the "Global" covid stats in the
- * [RegionDataPanel]
+ * Icon at right of search field. Tap to reveal global COVID stats; long-press to open
+ * cache statistics. The long-press label is announced by TalkBack so the action is
+ * discoverable without sight.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun GlobalRegionIcon(clickCallback: () -> Unit) {
+fun GlobalRegionIcon(clickCallback: () -> Unit, longClickCallback: () -> Unit) {
     Icon(
         imageVector = Icons.Default.AccountCircle,
         contentDescription = stringResource(R.string.region_global),
         modifier = Modifier
-            .clickable(role = Role.Button, onClick = clickCallback)
+            .combinedClickable(
+                role = Role.Button,
+                onClick = clickCallback,
+                onLongClick = longClickCallback,
+                onLongClickLabel = stringResource(R.string.cache_stats_title)
+            )
             .testTag(MainScreenTag.TAG_ICON_GLOBAL.tag)
             .size(48.dp)
     )
@@ -33,5 +41,5 @@ fun GlobalRegionIcon(clickCallback: () -> Unit) {
 @Preview
 @Composable
 fun GlobalRegionIconPreview() {
-    GlobalRegionIcon {}
+    GlobalRegionIcon(clickCallback = {}, longClickCallback = {})
 }

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/MainScreen.kt
@@ -23,16 +23,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -104,14 +99,11 @@ fun MainScreen(onNavigateToCacheStats: () -> Unit = {}) {
         snackbarHostState = snackbarHostState,
         onSearchTextChanged = onSearchTextChanged,
         onGlobalClicked = onGlobalClicked,
+        onGlobalLongClicked = onNavigateToCacheStats,
         onRegionClicked = onRegionClicked,
-        onDataPanelCollapsed = onDataPanelCollapsed,
-        onTripleTap = onNavigateToCacheStats
+        onDataPanelCollapsed = onDataPanelCollapsed
     )
 }
-
-/** Time window in milliseconds within which 3 taps must occur to count as a triple-tap. */
-private const val TRIPLE_TAP_TIMEOUT_MS = 500L
 
 /**
  * Stateless content for the main screen. Receives all state and callbacks as parameters,
@@ -121,48 +113,23 @@ private const val TRIPLE_TAP_TIMEOUT_MS = 500L
  * @param snackbarHostState Drives the Scaffold's SnackbarHost for error messages
  * @param onSearchTextChanged Invoked when the search field text changes
  * @param onGlobalClicked Invoked when the global stats icon is tapped
+ * @param onGlobalLongClicked Invoked when the global stats icon is long-pressed (opens cache stats)
  * @param onRegionClicked Invoked when a region list item is tapped
  * @param onDataPanelCollapsed Invoked when the data panel is tapped to collapse it
- * @param onTripleTap Invoked when three taps are detected within [TRIPLE_TAP_TIMEOUT_MS]
  */
-
 @Composable
 fun MainScreenContent(
     uiState: MainViewModel.UIState,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onSearchTextChanged: (String) -> Unit,
     onGlobalClicked: () -> Unit,
+    onGlobalLongClicked: () -> Unit = {},
     onRegionClicked: (Region) -> Unit,
-    onDataPanelCollapsed: () -> Unit,
-    onTripleTap: () -> Unit = {}
+    onDataPanelCollapsed: () -> Unit
 ) {
-    // Triple-tap state tracked at the composable level so it survives recomposition.
-    var tapCount by remember { mutableIntStateOf(0) }
-    var lastTapTime by remember { mutableLongStateOf(0L) }
-
-    // Observe pointer presses using PointerEventPass.Initial so child elements (search
-    // field, list items, data panel) still receive all their own touch events unaffected.
-    val tripleTapModifier = Modifier.pointerInput(onTripleTap) {
-        awaitPointerEventScope {
-            while (true) {
-                val event = awaitPointerEvent(PointerEventPass.Initial)
-                if (event.type == PointerEventType.Press) {
-                    val now = System.currentTimeMillis()
-                    tapCount = if (now - lastTapTime > TRIPLE_TAP_TIMEOUT_MS) 1 else tapCount + 1
-                    lastTapTime = now
-                    if (tapCount >= 3) {
-                        tapCount = 0
-                        onTripleTap()
-                    }
-                }
-            }
-        }
-    }
-
     Scaffold(
         modifier = Modifier
-            .fillMaxSize()
-            .then(tripleTapModifier),
+            .fillMaxSize(),
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { innerPadding ->
         Column(
@@ -178,7 +145,10 @@ fun MainScreenContent(
                     .fillMaxWidth()
                     .testTag(MainScreenTag.TAG_TEXT_SEARCH.tag),
                 trailingIcon = {
-                    GlobalRegionIcon(clickCallback = onGlobalClicked)
+                    GlobalRegionIcon(
+                        clickCallback = onGlobalClicked,
+                        longClickCallback = onGlobalLongClicked
+                    )
                 },
                 placeholder = { Text(text = stringResource(R.string.search_field_hint)) }
             )


### PR DESCRIPTION
## Summary
- Replaces the hidden triple-tap gesture (inaccessible to TalkBack users) with a long-press on the `GlobalRegionIcon` at the right of the search field
- `GlobalRegionIcon` now uses `combinedClickable` with `onLongClick` and `onLongClickLabel` — TalkBack announces *"double tap and hold for Cache Statistics"* when the icon is focused
- Removes all triple-tap state machinery from `MainScreen` (`tapCount`, `lastTapTime`, `tripleTapModifier`, `TRIPLE_TAP_TIMEOUT_MS`, `pointerInput` block)

## Test plan
- [ ] Tap the globe icon — confirm global stats panel opens as before
- [ ] Long-press the globe icon — confirm cache stats screen opens
- [ ] Enable TalkBack, focus the globe icon — confirm the long-press action label is announced
- [ ] Run existing instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)