### PR TITLE
fix: group bar chart label+value for TalkBack in HorizontalBarChart

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/cachestats/HorizontalBarChart.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/cachestats/HorizontalBarChart.kt
@@ -16,6 +16,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -74,7 +76,8 @@ private fun HorizontalBarRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(BAR_HEIGHT),
+            .height(BAR_HEIGHT)
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Fixed-width label column so all bars start at the same X position
@@ -85,11 +88,12 @@ private fun HorizontalBarRow(
             maxLines = 1
         )
 
-        // Bar — fills remaining width proportionally
+        // Bar — fills remaining width proportionally; purely visual, info is in the text nodes
         Box(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxHeight()
+                .semantics { hideFromAccessibility() }
         ) {
             Box(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- Added `semantics(mergeDescendants = true)` to the `Row` in `HorizontalBarRow` so TalkBack announces each bar as a single unit (e.g. "AFG 41m 18s") rather than traversing the label and value as separate focus targets
- Marked the coloured bar `Box` with `hideFromAccessibility()` since it is a purely visual element whose information is already conveyed by the label and value text nodes

## Test plan
- [ ] Enable TalkBack and navigate to the cache stats screen — confirm each bar row is announced as a single label+value unit (e.g. "AFG 41m 18s")
- [ ] Confirm the bar itself is not a separate TalkBack focus target
- [ ] Confirm visual layout is unchanged
- [ ] Run existing instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)