### PR TITLE
fix: add onClickLabel to region list items and data panel card

### DIFF
--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionDataPanel.kt
@@ -1,5 +1,6 @@
 package com.rodbailey.covid.presentation.main
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,7 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -22,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rodbailey.covid.R
 import com.rodbailey.covid.domain.ReportData
 import com.rodbailey.covid.presentation.MainViewModel
 import com.rodbailey.covid.presentation.core.UIText
@@ -36,7 +39,6 @@ private val EmptyReportData = ReportData()
  * @param dataPanelUIState Current state of the data panel — loading or open with data
  * @param clickCallback Invoked when user clicks on this panel
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RegionDataPanel(
     dataPanelUIState: MainViewModel.DataPanelUIState,
@@ -49,7 +51,12 @@ fun RegionDataPanel(
     val reportData = openWithData?.reportData ?: EmptyReportData
 
     Card(
-        onClick = clickCallback, modifier = Modifier
+        modifier = Modifier
+            .clickable(
+                role = Role.Button,
+                onClickLabel = stringResource(R.string.data_panel_collapse),
+                onClick = clickCallback
+            )
             .padding(horizontal = 16.dp)
             .fillMaxWidth()
             .testTag(MainScreenTag.TAG_CARD.tag)

--- a/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
+++ b/app/src/main/java/com/rodbailey/covid/presentation/main/RegionSearchResultItem.kt
@@ -12,11 +12,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rodbailey.covid.R
 import com.rodbailey.covid.domain.Region
 
 /**
@@ -33,6 +35,7 @@ fun RegionSearchResultItem(region: Region, clickCallback: () -> Unit) {
             .semantics(mergeDescendants = true) {}
             .clickable(
                 role = Role.Button,
+                onClickLabel = stringResource(R.string.region_view_stats_for, region.name),
                 onClick = clickCallback
             )
     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="no_data_available_for">No data available for \"%1$s\".</string>
     <string name="failed_to_load_country_list">Failed to load country list.</string>
     <string name="region_global">Global</string>
+    <string name="region_view_stats_for">View stats for %1$s</string>
+    <string name="data_panel_collapse">Collapse</string>
 
     <string name="data_field_confirmed">Confirmed:</string>
     <string name="data_field_deaths">Deaths:</string>


### PR DESCRIPTION
## Summary
- `RegionSearchResultItem`: added `onClickLabel = "View stats for [region name]"` to `clickable` so TalkBack announces *"double tap to view stats for Australia"* instead of the generic *"double tap to activate"*
- `RegionDataPanel`: added `onClickLabel = "Collapse"` so TalkBack announces *"double tap to Collapse"* when the stats card is focused
- `RegionDataPanel`: switched from the experimental `Card(onClick = …)` overload to the stable `Card` + `Modifier.clickable`, allowing removal of `@OptIn(ExperimentalMaterial3Api::class)`
- `strings.xml`: added `region_view_stats_for` and `data_panel_collapse` string resources

## Test plan
- [ ] Enable TalkBack and focus a region list item — confirm announcement includes *"double tap to view stats for [region name]"*
- [ ] Enable TalkBack and focus the data panel card — confirm announcement includes *"double tap to Collapse"*
- [ ] Confirm tapping a region list item and tapping the data panel card both behave as before
- [ ] Run existing instrumented tests: `./gradlew connectedAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)